### PR TITLE
make chunksize statically known from the cfg

### DIFF
--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -2,7 +2,12 @@ mutable struct HessianConfig{D <: AbstractVector{<:HyperDual}, S}
     const duals::D
     const seeds::S
 end
-(chunksize(cfg::HessianConfig)::Int) = length(cfg.seeds)
+@inline _chunksize(::Type{<:NTuple{N}}) where {N} = N
+if USE_SIMD
+    @inline _chunksize(::Type{<:Vec{N}}) where {N} = N
+end
+@inline _chunksize(seeds) = something(_chunksize(eltype(seeds)), length(seeds))
+(chunksize(cfg::HessianConfig)::Int) = _chunksize(cfg.seeds)::Int
 
 function HessianConfig(x::AbstractVector{T}, chunk = Chunk(x)::Chunk) where {T}
     N = chunksize(chunk)
@@ -21,7 +26,7 @@ mutable struct DirectionalHVPConfig{D <: AbstractVector{<:HyperDual}, S}
     const duals::D
     const seeds::S
 end
-(chunksize(cfg::DirectionalHVPConfig)::Int) = length(cfg.seeds)
+(chunksize(cfg::DirectionalHVPConfig)::Int) = _chunksize(cfg.seeds)
 
 function DirectionalHVPConfig(x::AbstractVector{T}, chunk = Chunk(x)::Chunk) where {T}
     N = chunksize(chunk)


### PR DESCRIPTION
Before this checked the length of a vector which was not statically resolvable. Now:

```
julia> @code_warntype optimize=true HyperHessians.chunksize(cfg_full)
MethodInstance for HyperHessians.chunksize(::HessianConfig{Vector{HyperHessians.HyperDual{8, 8, Float64}}, Vector{NTuple{8, Float64}}})
  from chunksize(cfg::HessianConfig) @ HyperHessians ~/JuliaPkgs/HyperHessians/src/hessian.jl:10
Arguments
  #self#::Core.Const(HyperHessians.chunksize)
  cfg::HessianConfig{Vector{HyperHessians.HyperDual{8, 8, Float64}}, Vector{NTuple{8, Float64}}}
Body::Int64
1 ─     nothing
│       nothing
└──     return 8
```