### PR TITLE
 allow hoisting computations involving f

### DIFF
--- a/ext/HyperHessiansLogExpFunctionsExt.jl
+++ b/ext/HyperHessiansLogExpFunctionsExt.jl
@@ -1,7 +1,7 @@
 module HyperHessiansLogExpFunctionsExt
 
 using HyperHessians
-using HyperHessians: changeprecision, rule_expr, chain_rule_dual, HyperDual
+using HyperHessians: changeprecision, rule_expr, rule_cse, chain_rule_dual, HyperDual
 using CommonSubexpressions: cse, binarize
 using LogExpFunctions
 
@@ -28,7 +28,7 @@ end
 
 for (f, f′, f′′) in LOGEXPFUNCTIONS_DIFF_RULES
     expr = rule_expr(f, f′, f′′)
-    cse_expr = cse(binarize(expr); warn = false)
+    cse_expr = rule_cse(expr; warn = false)
     @eval @inline function LogExpFunctions.$f(h::HyperDual{N1, N2, T}) where {N1, N2, T}
         x = h.v
         $cse_expr

--- a/ext/HyperHessiansNaNMathExt.jl
+++ b/ext/HyperHessiansNaNMathExt.jl
@@ -1,7 +1,7 @@
 module HyperHessiansNaNMathExt
 
 using HyperHessians
-using HyperHessians: changeprecision, chain_rule_dual, HyperDual
+using HyperHessians: changeprecision, chain_rule_dual, rule_cse, HyperDual
 using CommonSubexpressions: cse, binarize
 using NaNMath
 using SpecialFunctions: digamma, trigamma
@@ -76,7 +76,7 @@ end
 
 for (f, f′, f′′) in NANMATH_DIFF_RULES
     expr = nanmath_rule_expr(f, f′, f′′)
-    cse_expr = cse(binarize(expr); warn = false)
+    cse_expr = rule_cse(expr; warn = false)
     @eval @inline function NaNMath.$f(h::HyperDual{N1, N2, T}) where {N1, N2, T}
         x = h.v
         $cse_expr
@@ -86,7 +86,7 @@ end
 
 for (f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ) in NANMATH_BINARY_DIFF_RULES
     expr = nanmath_binary_rule_expr(f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ)
-    cse_expr = cse(binarize(expr); warn = false)
+    cse_expr = rule_cse(expr; warn = false)
     @eval @inline function NaNMath.$f(hx::HyperDual{N1, N2, T}, hy::HyperDual{N1, N2, T}) where {N1, N2, T}
         x = hx.v
         y = hy.v

--- a/ext/HyperHessiansSpecialFunctionsExt.jl
+++ b/ext/HyperHessiansSpecialFunctionsExt.jl
@@ -1,7 +1,7 @@
 module HyperHessiansSpecialFunctionsExt
 
 using HyperHessians
-using HyperHessians: rule_expr, chain_rule_dual, HyperDual
+using HyperHessians: rule_expr, rule_cse, chain_rule_dual, HyperDual
 using CommonSubexpressions: cse, binarize
 using SpecialFunctions
 using SpecialFunctions: sqrtπ
@@ -42,7 +42,7 @@ const SPECIALFUNCTIONS_DIFF_RULES = [
 
 for (f, f′, f′′) in SPECIALFUNCTIONS_DIFF_RULES
     expr = rule_expr(f, f′, f′′)
-    cse_expr = cse(binarize(expr); warn = false)
+    cse_expr = rule_cse(expr; warn = false)
     @eval @inline function SpecialFunctions.$f(h::HyperDual{N1, N2, T}) where {N1, N2, T}
         x = h.v
         $cse_expr


### PR DESCRIPTION
For example, the `f^3` is now hoisted:

<img width="1119" height="781" alt="gnome-shell-screenshot-4h91vl" src="https://github.com/user-attachments/assets/420bf9b6-d394-41cc-b0e9-df47176a1e89" />
