### PR TITLE
Add Jet: symmetric second-order numbers as an explicit opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It works similarly to `ForwardDiff.hessian` but should have better run-time and 
 | Type | Description |
 | ---- | ----------- |
 | `HessianConfig(x, chunk; simd)` | Config for Hessian calls |
+| `HessianConfig(x, Jet; simd)` | Config using the symmetric `Jet` representation |
 | `ThreadedHessianConfig(x, chunk; ntasks, simd)` | Config for multithreaded Hessian calls |
 | `HVPConfig(x, chunk)` | Config for Hessian–vector products |
 | `VHVPConfig(x, v)` | Config for vector-Hessian-vector products |
@@ -60,6 +61,29 @@ julia> f(x) = exp(x) / sqrt(sin(x)^3 + cos(x)^3);
 julia> HyperHessians.hessian(f, 2.0)
 82.55705026089272
 ```
+
+### Jets
+
+Passing `HyperHessians.Jet` instead of a `Chunk` selects a symmetric "jet"
+number: the whole Hessian is computed in a single evaluation of `f`, and since
+both derivative directions then carry the same seeds, the jet stores the
+gradient once and only the upper triangle of the Hessian
+(1 + n + n(n+1)/2 floats instead of `HyperDual{n,n}`'s 1 + 2n + n²):
+
+```julia
+cfg = HyperHessians.HessianConfig(x, HyperHessians.Jet)              # jet representation
+cfg = HyperHessians.HessianConfig(x, HyperHessians.Jet; simd = true) # with SIMD.Vec arithmetic
+```
+
+Jets tend to win for small inputs where register pressure dominates, while
+chunked `HyperDual`s vectorize better as the input grows; the crossover
+depends on the function and CPU, so jets are never selected by default —
+benchmark, or let
+[ChunkPicker.jl](https://github.com/KristofferC/ChunkPicker.jl) decide.
+They are only sensible for small inputs: the unrolled triangle makes compile
+time grow steeply with `length(x)`, and with `simd = true` the triangle
+becomes a single `n(n+1)/2`-lane `Vec`, which degrades sharply once that
+exceeds a few machine vector widths.
 
 ### Fast math
 

--- a/ext/HyperHessiansForwardDiffExt.jl
+++ b/ext/HyperHessiansForwardDiffExt.jl
@@ -1,41 +1,49 @@
 module HyperHessiansForwardDiffExt
 
-# Mixing HyperDual (e.g. from hessian seeding) with ForwardDiff.Dual (e.g.
-# from a derivative computed inside the function being differentiated) is
-# ambiguous out of the box, since both packages define methods against
-# ::Real. Resolve the ambiguities by letting the Dual wrap the HyperDual,
-# just like ForwardDiff wraps any other Real: forward to the ForwardDiff
-# method with the HyperDual passed as a generic Real scalar.
+# Mixing HyperDual or Jet (e.g. from hessian seeding) with ForwardDiff.Dual
+# (e.g. from a derivative computed inside the function being differentiated)
+# is ambiguous out of the box, since both packages define methods against
+# ::Real. Resolve the ambiguities by letting the Dual wrap the second-order
+# number, just like ForwardDiff wraps any other Real: forward to the
+# ForwardDiff method with the HyperDual/Jet passed as a generic Real scalar.
 
-using HyperHessians: HyperDual
+using HyperHessians: HyperDual, Jet
 using ForwardDiff: ForwardDiff, Dual
 
-for f in (:+, :-, :*, :/, :^, :atan, :hypot, :log, :<, :<=, :(==), :isless)
+for H in (HyperDual, Jet)
+    for f in (:+, :-, :*, :/, :^, :atan, :hypot, :log, :<, :<=, :(==), :isless)
+        @eval begin
+            @inline Base.$f(h::$H, d::Dual) = invoke(Base.$f, Tuple{Real, typeof(d)}, h, d)
+            @inline Base.$f(d::Dual, h::$H) = invoke(Base.$f, Tuple{typeof(d), Real}, d, h)
+        end
+    end
     @eval begin
-        @inline Base.$f(h::HyperDual, d::Dual) = invoke(Base.$f, Tuple{Real, typeof(d)}, h, d)
-        @inline Base.$f(d::Dual, h::HyperDual) = invoke(Base.$f, Tuple{typeof(d), Real}, d, h)
+        @inline Base.mod(h::$H, d::Dual) = invoke(Base.mod, Tuple{Real, typeof(d)}, h, d)
+        @inline Base.rem(h::$H, d::Dual) = invoke(Base.rem, Tuple{Real, typeof(d)}, h, d)
+        @inline ForwardDiff.NaNMath.pow(h::$H, d::Dual) = invoke(ForwardDiff.NaNMath.pow, Tuple{Real, typeof(d)}, h, d)
+        @inline ForwardDiff.NaNMath.pow(d::Dual, h::$H) = invoke(ForwardDiff.NaNMath.pow, Tuple{typeof(d), Real}, d, h)
     end
 end
-@inline Base.mod(h::HyperDual, d::Dual) = invoke(Base.mod, Tuple{Real, typeof(d)}, h, d)
-@inline Base.rem(h::HyperDual, d::Dual) = invoke(Base.rem, Tuple{Real, typeof(d)}, h, d)
-@inline ForwardDiff.NaNMath.pow(h::HyperDual, d::Dual) = invoke(ForwardDiff.NaNMath.pow, Tuple{Real, typeof(d)}, h, d)
-@inline ForwardDiff.NaNMath.pow(d::Dual, h::HyperDual) = invoke(ForwardDiff.NaNMath.pow, Tuple{typeof(d), Real}, d, h)
 
 Base.promote_rule(::Type{HyperDual{N1, N2, T, S}}, ::Type{Dual{Ty, V, N}}) where {N1, N2, T, S, Ty, V, N} =
     Dual{Ty, promote_type(HyperDual{N1, N2, T, S}, V), N}
+Base.promote_rule(::Type{Jet{NJ, M, T, S}}, ::Type{Dual{Ty, V, N}}) where {NJ, M, T, S, Ty, V, N} =
+    Dual{Ty, promote_type(Jet{NJ, M, T, S}, V), N}
 
-# muladd: all mixed HyperDual/Dual argument combinations. ForwardDiff defines
-# its ternary ops against every type in AMBIGUOUS_TYPES (not just Real), so
-# the remaining non-HyperDual/non-Dual slot must be split over the same set
-# for the mixed methods to be strictly more specific than all of them.
+# muladd: all mixed HyperDual-or-Jet/Dual argument combinations. ForwardDiff
+# defines its ternary ops against every type in AMBIGUOUS_TYPES (not just
+# Real), so the remaining non-HyperDual/non-Dual slot must be split over the
+# same set for the mixed methods to be strictly more specific than all of them.
 const _OTHERS = Tuple(T for T in ForwardDiff.AMBIGUOUS_TYPES if T <: Real)
-for pat in Iterators.product((:H, :D, :O), (:H, :D, :O), (:H, :D, :O))
-    (:H in pat && :D in pat) || continue
-    names = (:x, :y, :z)
-    ivk = [pat[i] === :H ? Real : :(typeof($(names[i]))) for i in 1:3]
-    for Q in (:O in pat ? _OTHERS : (nothing,))
-        sig = [:($(names[i])::$(pat[i] === :H ? HyperDual : pat[i] === :D ? Dual : Q)) for i in 1:3]
-        @eval @inline Base.muladd($(sig...)) = invoke(Base.muladd, Tuple{$(ivk...)}, x, y, z)
+for H in (HyperDual, Jet)
+    for pat in Iterators.product((:H, :D, :O), (:H, :D, :O), (:H, :D, :O))
+        (:H in pat && :D in pat) || continue
+        names = (:x, :y, :z)
+        ivk = [pat[i] === :H ? Real : :(typeof($(names[i]))) for i in 1:3]
+        for Q in (:O in pat ? _OTHERS : (nothing,))
+            sig = [:($(names[i])::$(pat[i] === :H ? H : pat[i] === :D ? Dual : Q)) for i in 1:3]
+            @eval @inline Base.muladd($(sig...)) = invoke(Base.muladd, Tuple{$(ivk...)}, x, y, z)
+        end
     end
 end
 

--- a/ext/HyperHessiansLogExpFunctionsExt.jl
+++ b/ext/HyperHessiansLogExpFunctionsExt.jl
@@ -1,7 +1,7 @@
 module HyperHessiansLogExpFunctionsExt
 
 using HyperHessians
-using HyperHessians: changeprecision, rule_expr, rule_cse, chain_rule_dual, HyperDual
+using HyperHessians: changeprecision, rule_expr, rule_cse, chain_rule_dual, HyperDual, chain_rule_jet, Jet
 using CommonSubexpressions: cse, binarize
 using LogExpFunctions
 
@@ -33,6 +33,11 @@ for (f, f′, f′′) in LOGEXPFUNCTIONS_DIFF_RULES
         x = h.v
         $cse_expr
         return chain_rule_dual(h, f, f′, f′′)
+    end
+    @eval @inline function LogExpFunctions.$f(j::Jet{N, M, T}) where {N, M, T}
+        x = j.v
+        $cse_expr
+        return chain_rule_jet(j, f, f′, f′′)
     end
 end
 

--- a/ext/HyperHessiansNaNMathExt.jl
+++ b/ext/HyperHessiansNaNMathExt.jl
@@ -1,7 +1,7 @@
 module HyperHessiansNaNMathExt
 
 using HyperHessians
-using HyperHessians: changeprecision, chain_rule_dual, rule_cse, HyperDual
+using HyperHessians: changeprecision, chain_rule_dual, rule_cse, HyperDual, chain_rule_jet, Jet
 using CommonSubexpressions: cse, binarize
 using NaNMath
 
@@ -80,6 +80,11 @@ for (f, f′, f′′) in NANMATH_DIFF_RULES
         $cse_expr
         return chain_rule_dual(h, f, f′, f′′)
     end
+    @eval @inline function NaNMath.$f(j::Jet{N, M, T}) where {N, M, T}
+        x = j.v
+        $cse_expr
+        return chain_rule_jet(j, f, f′, f′′)
+    end
 end
 
 for (f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ) in NANMATH_BINARY_DIFF_RULES
@@ -97,17 +102,47 @@ for (f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ) in NANMATH_BINARY_DIFF_RULES
     @eval @inline function NaNMath.$f(hx::HyperDual{N1, N2, T}, y_raw::Real) where {N1, N2, T}
         y_raw isa HyperDual{N1, N2} && return NaNMath.$f(promote(hx, y_raw)...)
         x = hx.v
-        y = T(y_raw)
+        y = y_raw
         $cse_expr
         return chain_rule_dual(hx, f, fₓ, fₓₓ)
     end
     @eval @inline function NaNMath.$f(x_raw::Real, hy::HyperDual{N1, N2, T}) where {N1, N2, T}
         x_raw isa HyperDual{N1, N2} && return NaNMath.$f(promote(x_raw, hy)...)
-        x = T(x_raw)
+        x = x_raw
         y = hy.v
         $cse_expr
         return chain_rule_dual(hy, f, fᵧ, fᵧᵧ)
     end
+
+    @eval @inline function NaNMath.$f(jx::Jet{N, M, T, S}, jy::Jet{N, M, T, S}) where {N, M, T, S}
+        x = jx.v
+        y = jy.v
+        $cse_expr
+        return chain_rule_jet(jx, jy, f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ)
+    end
+    @eval @inline function NaNMath.$f(jx::Jet{N, M}, jy::Jet{N, M}) where {N, M}
+        return NaNMath.$f(promote(jx, jy)...)
+    end
+    @eval @inline function NaNMath.$f(jx::Jet{N, M, T}, y_raw::Real) where {N, M, T}
+        y_raw isa Jet{N, M} && return NaNMath.$f(promote(jx, y_raw)...)
+        x = jx.v
+        y = y_raw
+        $cse_expr
+        return chain_rule_jet(jx, f, fₓ, fₓₓ)
+    end
+    @eval @inline function NaNMath.$f(x_raw::Real, jy::Jet{N, M, T}) where {N, M, T}
+        x_raw isa Jet{N, M} && return NaNMath.$f(promote(x_raw, jy)...)
+        x = x_raw
+        y = jy.v
+        $cse_expr
+        return chain_rule_jet(jy, f, fᵧ, fᵧᵧ)
+    end
 end
+
+# NaNMath.pow(x::Real, y::Integer) forwards to ^; do the same for the dual
+# types, which also resolves the dispatch ambiguity between that method and
+# the scalar-slot methods above.
+@inline NaNMath.pow(h::HyperDual, n::Integer) = h^n
+@inline NaNMath.pow(j::Jet, n::Integer) = j^n
 
 end

--- a/ext/HyperHessiansNaNMathSpecialFunctionsExt.jl
+++ b/ext/HyperHessiansNaNMathSpecialFunctionsExt.jl
@@ -1,6 +1,6 @@
 module HyperHessiansNaNMathSpecialFunctionsExt
 
-using HyperHessians: HyperDual, chain_rule_dual
+using HyperHessians: HyperDual, chain_rule_dual, Jet, chain_rule_jet
 using NaNMath
 using SpecialFunctions: digamma, trigamma
 
@@ -8,6 +8,12 @@ using SpecialFunctions: digamma, trigamma
     x = h.v
     f = NaNMath.lgamma(x)
     return chain_rule_dual(h, f, digamma(x), trigamma(x))
+end
+
+@inline function NaNMath.lgamma(j::Jet{N, M}) where {N, M}
+    x = j.v
+    f = NaNMath.lgamma(x)
+    return chain_rule_jet(j, f, digamma(x), trigamma(x))
 end
 
 end

--- a/ext/HyperHessiansSpecialFunctionsExt.jl
+++ b/ext/HyperHessiansSpecialFunctionsExt.jl
@@ -1,7 +1,7 @@
 module HyperHessiansSpecialFunctionsExt
 
 using HyperHessians
-using HyperHessians: rule_expr, rule_cse, chain_rule_dual, HyperDual
+using HyperHessians: rule_expr, rule_cse, chain_rule_dual, HyperDual, chain_rule_jet, Jet
 using CommonSubexpressions: cse, binarize
 using SpecialFunctions
 using SpecialFunctions: sqrtπ
@@ -47,6 +47,11 @@ for (f, f′, f′′) in SPECIALFUNCTIONS_DIFF_RULES
         x = h.v
         $cse_expr
         return chain_rule_dual(h, f, f′, f′′)
+    end
+    @eval @inline function SpecialFunctions.$f(j::Jet{N, M, T}) where {N, M, T}
+        x = j.v
+        $cse_expr
+        return chain_rule_jet(j, f, f′, f′′)
     end
 end
 

--- a/src/HyperHessians.jl
+++ b/src/HyperHessians.jl
@@ -1,7 +1,7 @@
 module HyperHessians
 
 if VERSION >= v"1.11.0-"
-    eval(Meta.parse("public hessian, hessian!, hessian_gradient_value, hessian_gradient_value!, hvp, hvp!, hvp_gradient_value, hvp_gradient_value!, vhvp, vhvp_gradient_value, VHVPConfig, HessianConfig, ThreadedHessianConfig, HVPConfig, Chunk"))
+    eval(Meta.parse("public hessian, hessian!, hessian_gradient_value, hessian_gradient_value!, hvp, hvp!, hvp_gradient_value, hvp_gradient_value!, vhvp, vhvp_gradient_value, VHVPConfig, HessianConfig, ThreadedHessianConfig, HVPConfig, Chunk, Jet"))
 end
 
 
@@ -9,6 +9,7 @@ using CommonSubexpressions: cse, binarize
 using SIMD: Vec
 
 include("hyperdual.jl")
+include("jet.jl")
 include("rules.jl")
 include("chunks.jl")
 include("hessian.jl")

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -1,4 +1,6 @@
-mutable struct HessianConfig{D <: AbstractVector{<:HyperDual}, S}
+# The seeds constraint keeps the raw two-field constructor from competing
+# with the `HessianConfig(x, chunk)` / `HessianConfig(x, Jet)` constructors.
+mutable struct HessianConfig{D <: AbstractVector{<:SecondOrderNumber}, S <: AbstractVector{<:Tuple}}
     const duals::D
     const seeds::S
 end
@@ -8,14 +10,27 @@ end
 
 """
     HessianConfig(x[, chunk::Chunk]; simd = false)
+    HessianConfig(x, Jet; simd = false)
 
 Configuration for `hessian`/`hessian!`. `simd = true` uses SIMD.Vec-forced
 arithmetic for the derivative components (only effective for `Float32`/
 `Float64` elements); whether that is faster depends on the function, chunk
 size, and CPU — benchmark, or let ChunkPicker.jl decide.
 
-The flag becomes a type parameter of the config: a constant `simd` infers
-to a concrete config type, a runtime one to a two-type `Union`.
+Passing the [`Jet`](@ref) type instead of a `Chunk` selects the symmetric jet
+representation: the whole Hessian in a single evaluation of `f`, storing the
+gradient once and only the upper triangle. Never selected by default; whether
+it beats a chunked `HyperDual` config depends on the function, input length,
+and CPU — benchmark, or let ChunkPicker.jl decide. Jets are only sensible for
+small inputs: the unrolled triangle makes compile time grow steeply with
+`length(x)`, and with `simd = true` the triangle tuple becomes a single
+`Vec` of `N(N+1)/2` lanes, which degrades sharply once that exceeds a few
+machine vector widths (measured ~100x at `length(x) >= 8` on AVX2).
+
+The flags become type parameters of the config: for the chunked constructor
+a constant `simd` infers to a concrete config type, a runtime one to a
+two-type `Union` (the jet config type additionally depends on `length(x)`,
+which is not known to inference).
 """
 Base.@constprop :aggressive function HessianConfig(x::AbstractVector{T}, chunk = Chunk(x)::Chunk; simd::Bool = false) where {T}
     N = chunksize(chunk)
@@ -29,6 +44,18 @@ Base.@constprop :aggressive function HessianConfig(x::AbstractVector{T}, chunk =
 end
 Base.@constprop :aggressive HessianConfig(x::AbstractArray{T}, chunk = Chunk(x)::Chunk; simd::Bool = false) where {T} =
     HessianConfig(vec(x), chunk; simd)
+
+# Explicit opt-in to the jet representation (never the default).
+Base.@constprop :aggressive function HessianConfig(x::AbstractVector{T}, ::Type{Jet}; simd::Bool = false) where {T}
+    isempty(x) && throw(ArgumentError("jet configuration requires a non-empty input"))
+    N = length(x)
+    D = simd ? Jet{N, nupper(N), T, true} : Jet{N, nupper(N), T, false}
+    duals = similar(x, D)
+    seeds = NTuple{N, T}[construct_seeds(NTuple{N, T})...]
+    return HessianConfig(duals, seeds)
+end
+Base.@constprop :aggressive HessianConfig(x::AbstractArray, ::Type{Jet}; simd::Bool = false) =
+    HessianConfig(vec(x), Jet; simd)
 
 """
     ThreadedHessianConfig(x, chunk::Chunk = Chunk(x); ntasks = Threads.nthreads(), simd = false)
@@ -219,6 +246,11 @@ end
 @inline _ensure_dual(v::Real, d::AbstractVector{<:HyperDual{N1, N2}}) where {N1, N2} =
     HyperDual{N1, N2, typeof(v), _simd_of(eltype(d))}(v)
 @inline _ensure_dual(v::Real, ::HyperDual{N1, N2}) where {N1, N2} = HyperDual{N1, N2}(v)
+@inline _simd_of(::Type{Jet{N, M, T, S}}) where {N, M, T, S} = S
+@inline _simd_of(::Type{<:Jet}) = false
+@inline _ensure_dual(v::Jet{N, M}, ::AbstractVector{<:Jet{N, M}}) where {N, M} = v
+@inline _ensure_dual(v::Real, d::AbstractVector{<:Jet{N, M}}) where {N, M} =
+    Jet{N, M, typeof(v), _simd_of(eltype(d))}(v)
 
 @inline _vectorize_input(f, x::AbstractVector) = (f, x, nothing)
 @inline function _vectorize_input(f, x::AbstractArray)
@@ -264,11 +296,11 @@ function extract_hessian!(H::AbstractMatrix, v::HyperDual)
 end
 
 function symmetrize!(H::AbstractMatrix)
+    # enumerate the axes: positions pick the triangle, i/j index H (which may
+    # not be 1-based)
     ax1, ax2 = axes(H, 1), axes(H, 2)
-    @inbounds for i_pos in 1:length(ax1)
-        i = ax1[i_pos]
-        for j_pos in i_pos:length(ax2)
-            j = ax2[j_pos]
+    @inbounds for (i_pos, i) in enumerate(ax1)
+        for (_, j) in Iterators.drop(enumerate(ax2), i_pos - 1)
             H[j, i] = H[i, j]
         end
     end
@@ -354,7 +386,59 @@ function hessian!(H::AbstractMatrix, f::F, x::AbstractArray, cfg::AnyHessianConf
     return hessian!(H, f_vec, x_vec, cfg)
 end
 
-function hessian_core!(H::AbstractMatrix, G::Union{Nothing, AbstractVector}, f, x::AbstractVector{T}, cfg::HessianConfig) where {T}
+# Jet path: one evaluation, gradient read from j.g, Hessian upper triangle
+# from j.h, mirrored into the lower triangle.
+const JetHessianConfig = HessianConfig{<:AbstractVector{<:Jet}}
+
+function hessian_jet_core!(H::AbstractMatrix, G::Union{Nothing, AbstractVector}, f::F, x::AbstractVector{T}, cfg::JetHessianConfig) where {F, T}
+    size(H, 1) == size(H, 2) == length(x) || throw(DimensionMismatch(lazy"H must be square with size matching length(x)=$(length(x)), got size(H)=$(size(H))"))
+    G === nothing || length(G) == length(x) || throw(DimensionMismatch(lazy"gradient must have length $(length(x)), got $(length(G))"))
+    duals = cfg.duals
+    seeds = cfg.seeds
+    JT = eltype(duals)
+    MT = fieldtype(JT, :h)
+    zeroh = zero_ϵ(MT)
+    # zip the index sets: duals and x are equal-length but may have
+    # different axes (e.g. a config reused with another array type)
+    @inbounds for (k, (i, ix)) in enumerate(zip(eachindex(duals), eachindex(x)))
+        duals[i] = JT(x[ix], seeds[k], zeroh)
+    end
+    v = f(duals)
+    check_scalar(v)
+    v = _ensure_dual(v, duals)
+    if G !== nothing
+        @inbounds for (k, i) in enumerate(eachindex(G))
+            G[i] = v.g[k]
+        end
+    end
+    # enumerate the axes: positions index the triangle, i/j index H (which
+    # may not be 1-based)
+    ax1, ax2 = axes(H, 1), axes(H, 2)
+    k = 0
+    @inbounds for (i_pos, i) in enumerate(ax1)
+        for (_, j) in Iterators.drop(enumerate(ax2), i_pos - 1)
+            k += 1
+            H[i, j] = v.h[k]
+            H[j, i] = v.h[k]
+        end
+    end
+    return v.v
+end
+
+function hessian!(H::AbstractMatrix, f::F, x::AbstractVector{T}, cfg::JetHessianConfig) where {F, T}
+    _check_config_length(cfg, length(x))
+    hessian_jet_core!(H, nothing, f, x, cfg)
+    return H
+end
+
+function hessian_gradient_value!(H::AbstractMatrix, G::AbstractVector, f::F, x::AbstractVector{T}, cfg::JetHessianConfig) where {F, T}
+    _check_config_length(cfg, length(x))
+    return hessian_jet_core!(H, G, f, x, cfg)
+end
+
+# Restricted to HyperDual configs so a jet config missing a JetHessianConfig
+# overload is a MethodError instead of silently computing garbage here.
+function hessian_core!(H::AbstractMatrix, G::Union{Nothing, AbstractVector}, f, x::AbstractVector{T}, cfg::HessianConfig{<:AbstractVector{<:HyperDual}}) where {T}
     size(H, 1) == size(H, 2) == length(x) || throw(DimensionMismatch(lazy"H must be square with size matching length(x)=$(length(x)), got size(H)=$(size(H))"))
     G === nothing || length(G) == length(x) || throw(DimensionMismatch(lazy"gradient must have length $(length(x)), got $(length(G))"))
     ax = axes(x, 1)

--- a/src/jet.jl
+++ b/src/jet.jl
@@ -1,0 +1,459 @@
+#=
+# Jets: symmetric second-order numbers
+
+A `Jet` is the specialization of `HyperDual{N, N}` to the case where ϵ₁ and ϵ₂
+carry the same seeds — which is exactly full-vector mode (one evaluation with
+identity seeds, chunk size == input length). In that case ϵ₁ == ϵ₂ at every
+intermediate value and ϵ₁₂ is symmetric, so a HyperDual stores (and computes)
+the gradient twice and both triangles of the Hessian block. A Jet stores each
+once:
+
+    j = v + gᵀε + εᵀHε,   H symmetric, upper triangle stored row-major
+
+which is 1 + N + N(N+1)/2 floats instead of HyperDual{N,N}'s 1 + 2N + N².
+The rules follow from the HyperDual rules with a = b = g and A = H:
+
+    (j₁ * j₂).h[i,j] = v₁H₂[i,j] + H₁[i,j]v₂ + g₁[i]g₂[j] + g₂[i]g₁[j]
+    f(j).h[i,j]      = f′(v)H[i,j] + f″(v)g[i]g[j]
+
+Measured tradeoff: jets tend to win for small inputs where register pressure
+dominates, but the ragged triangle rows (N, N-1, …, 1) vectorize poorly as
+they grow, and a full-vector HyperDual{N,N} becomes register-exact once N
+reaches the SIMD width (N = 4 on AVX2, N = 8 on AVX-512), winning again from
+there. The crossover is function- and CPU-dependent, so jets are never
+selected by default: opt in with `HessianConfig(x, Jet)`, or let
+ChunkPicker.jl benchmark the candidates.
+
+Like HyperDual, all arithmetic is parameterized over an `ArithmeticMode` and
+the `S` backend flag: `@fastmath` in the differentiated function propagates
+through the derivative components (see the `Base.FastMath` methods at the
+bottom and the fast rule variants generated in rules.jl), and `S = true`
+(`HessianConfig(x, Jet; simd = true)`) forces SIMD.Vec arithmetic on the
+gradient and triangle tuples via the shared `_add`/`_mul`/… backend ops in
+hyperdual.jl.
+=#
+
+"""
+    Jet{N, M, T, S} <: Real
+
+Symmetric second-order number: a value, a gradient of length `N`, and the
+upper triangle of the Hessian (`M = N(N+1)/2` entries, row-major). Computes a
+whole Hessian in a single function evaluation; select it with
+`HessianConfig(x, Jet; simd)`. `S` selects the arithmetic backend as for
+`HyperDual`: `false` = plain tuple ops (works for any `T`), `true` =
+SIMD.Vec-forced ops for `Float32`/`Float64` components.
+"""
+struct Jet{N, M, T, S} <: Real
+    v::T
+    g::NTuple{N, T}
+    h::NTuple{M, T}
+end
+
+const SecondOrderNumber = Union{HyperDual, Jet}
+
+@inline nupper(N::Int) = N * (N + 1) ÷ 2
+
+# Internal constructors preserving the backend flag of the operands.
+@inline jet(mode::ArithmeticMode, v, g, h) = jet(Val(_simd(mode)), v, g, h)
+@inline jet(::Val{S}, v::T, g::ϵT{N, T}, h::ϵT{M, T}) where {S, N, M, T} =
+    Jet{N, M, T, S}(v, g, h)
+@inline function jet(::Val{S}, v::T1, g::ϵT{N, T2}, h::ϵT{M, T3}) where {S, N, M, T1, T2, T3}
+    T = promote_type(T1, T2, T3)
+    return Jet{N, M, T, S}(T(v), to_ϵ(ϵT{N, T}, g), to_ϵ(ϵT{M, T}, h))
+end
+
+@inline _ieee_mode(::Jet{N, M, T, S}) where {N, M, T, S} = IEEEArithmetic{S}()
+@inline _fast_mode(::Jet{N, M, T, S}) where {N, M, T, S} = FastArithmetic{S}()
+
+# Public constructors default to the tuple backend.
+function Jet(v::T1, g::ϵT{N, T2}, h::ϵT{M, T3}) where {N, M, T1, T2, T3}
+    M == nupper(N) || throw(ArgumentError(lazy"h must hold the N(N+1)/2 = $(nupper(N)) upper-triangle entries, got $M"))
+    return jet(Val(false), v, g, h)
+end
+Jet{N, M}(v::T) where {N, M, T} =
+    Jet{N, M, T, false}(v, ntuple(_ -> zero(T), Val(N)), ntuple(_ -> zero(T), Val(M)))
+Jet{N, M, T}(v) where {N, M, T} = Jet{N, M}(T(v))
+Jet{N, M, T}(v::Jet{N, M, T}) where {N, M, T} = v
+Jet{N, M, T}(v::Jet{N, M, <:Any, S}) where {N, M, T, S} = convert(Jet{N, M, T, S}, v)
+Jet{N, M}(v::Jet{N, M}) where {N, M} = v
+
+Jet{N, M, T, S}(v::Real) where {N, M, T, S} = jet(
+    Val(S), T(v),
+    ntuple(_ -> zero(T), Val(N)), ntuple(_ -> zero(T), Val(M)),
+)
+Jet{N, M, T, S}(v::Jet{N, M, T, S}) where {N, M, T, S} = v
+Jet{N, M, T, S}(v::Jet{N, M}) where {N, M, T, S} = convert(Jet{N, M, T, S}, v)
+
+# Disambiguate against Base's numeric conversion constructors, mirroring
+# HyperDual (see hyperdual.jl).
+for R in (:Complex, :AbstractChar, :(Base.TwicePrecision))
+    @eval Jet{N, M, T}(v::$R) where {N, M, T} = Jet{N, M}(T(_scalar(v)))
+    @eval Jet{N, M}(v::$R) where {N, M} = Jet{N, M}(_scalar(v))
+    @eval Jet{N, M, T, S}(v::$R) where {N, M, T, S} = Jet{N, M, T, S}(T(_scalar(v)))
+end
+
+@inline value(x::Jet) = x.v
+
+# Mixed backends promote to the tuple backend.
+Base.promote_rule(::Type{Jet{N, M, T1, S1}}, ::Type{Jet{N, M, T2, S2}}) where {N, M, T1, T2, S1, S2} =
+    Jet{N, M, promote_type(T1, T2), S1 && S2}
+Base.promote_rule(::Type{Jet{N, M, T1, S}}, ::Type{T2}) where {N, M, T1, S, T2 <: Real} =
+    Jet{N, M, promote_type(T1, T2), S}
+Base.convert(::Type{Jet{N, M, T1, S}}, j::Jet{N, M, T2, S2}) where {N, M, T1, T2, S, S2} =
+    Jet{N, M, T1, S}(T1(j.v), to_ϵ(ϵT{N, T1}, j.g), to_ϵ(ϵT{M, T1}, j.h))
+Base.convert(::Type{Jet{N, M, T, S}}, x::Real) where {N, M, T, S} = Jet{N, M, T, S}(T(x))
+
+function Base.show(io::IO, j::Jet)
+    print(io, j.v, " + ", Tuple(j.g), "ε + ", Tuple(j.h), "ε² (upper)")
+    return
+end
+
+Base.one(::Type{Jet{N, M, T, S}}) where {N, M, T, S} = Jet{N, M, T, S}(one(T))
+Base.zero(::Type{Jet{N, M, T, S}}) where {N, M, T, S} = Jet{N, M, T, S}(zero(T))
+Base.one(::Type{Jet{N, M, T}}) where {N, M, T} = one(Jet{N, M, T, false})
+Base.zero(::Type{Jet{N, M, T}}) where {N, M, T} = zero(Jet{N, M, T, false})
+Base.one(::Jet{N, M, T, S}) where {N, M, T, S} = one(Jet{N, M, T, S})
+Base.zero(::Jet{N, M, T, S}) where {N, M, T, S} = zero(Jet{N, M, T, S})
+Base.float(j::Jet{N, M, T, S}) where {N, M, T, S} = convert(Jet{N, M, float(T), S}, j)
+
+# Upper-triangle helpers, fully unrolled with literal indices so LLVM sees
+# straight-line tuple code.
+@inline @generated function symouter(mode::ArithmeticMode, a::NTuple{N, T}, b::NTuple{N, T}) where {N, T}
+    ex = Expr(:tuple)
+    for i in 1:N, j in i:N
+        push!(ex.args, :(_muladd(mode, a[$i], b[$j], _mul(mode, b[$i], a[$j]))))
+    end
+    return ex
+end
+
+@inline @generated function halfouter(mode::ArithmeticMode, a::NTuple{N, T}) where {N, T}
+    ex = Expr(:tuple)
+    for i in 1:N, j in i:N
+        push!(ex.args, :(_mul(mode, a[$i], a[$j])))
+    end
+    return ex
+end
+
+"""
+    chain_rule_jet(j::Jet, f, f′, f′′)
+
+Apply the chain rule to `j` given scalar primal `f`, first derivative `f′`,
+and second derivative `f′′`.
+"""
+@inline chain_rule_jet(j::Jet, f, f′, f′′) = chain_rule_jet(_ieee_mode(j), j, f, f′, f′′)
+
+@inline function chain_rule_jet(mode::ArithmeticMode, j::Jet{N, M, T}, f, f′, f′′) where {N, M, T}
+    return jet(
+        mode,
+        f,
+        _mul(mode, j.g, f′),
+        _muladd(mode, f′, j.h, _mul(mode, halfouter(mode, j.g), f′′)),
+    )
+end
+
+"""
+    chain_rule_jet(jx::Jet, jy::Jet, f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ)
+
+Apply the chain rule to a scalar function of two `Jet` inputs given first and
+second partial derivatives.
+"""
+@inline chain_rule_jet(jx::Jet, jy::Jet, f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ) =
+    chain_rule_jet(_ieee_mode(jx), jx, jy, f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ)
+
+@inline function chain_rule_jet(
+        mode::ArithmeticMode,
+        jx::Jet{N, M, T},
+        jy::Jet{N, M, T},
+        f,
+        fₓ,
+        fᵧ,
+        fₓₓ,
+        fₓᵧ,
+        fᵧᵧ,
+    ) where {N, M, T}
+    g = _muladd(mode, fₓ, jx.g, _mul(mode, jy.g, fᵧ))
+    h = _muladd(mode, fₓ, jx.h, _mul(mode, jy.h, fᵧ))
+    h = _muladd(mode, fₓₓ, halfouter(mode, jx.g), h)
+    h = _muladd(mode, fₓᵧ, symouter(mode, jx.g, jy.g), h)
+    h = _muladd(mode, fᵧᵧ, halfouter(mode, jy.g), h)
+    return jet(mode, f, g, h)
+end
+
+# Arithmetic
+@inline function _neg_jet(mode::ArithmeticMode, j::Jet{N, M, T}) where {N, M, T}
+    return jet(mode, _neg(mode, j.v), _neg(mode, j.g), _neg(mode, j.h))
+end
+
+@inline function _add_jet(mode::ArithmeticMode, a::Jet{N, M, T}, b::Jet{N, M, T}) where {N, M, T}
+    return jet(mode, _add(mode, a.v, b.v), _add(mode, a.g, b.g), _add(mode, a.h, b.h))
+end
+
+@inline function _sub_jet(mode::ArithmeticMode, a::Jet{N, M, T}, b::Jet{N, M, T}) where {N, M, T}
+    return jet(mode, _sub(mode, a.v, b.v), _sub(mode, a.g, b.g), _sub(mode, a.h, b.h))
+end
+
+@inline function _mul_jet(mode::ArithmeticMode, a::Jet{N, M, T}, b::Jet{N, M, T}) where {N, M, T}
+    return jet(
+        mode,
+        _mul(mode, a.v, b.v),
+        _muladd(mode, a.v, b.g, _mul(mode, a.g, b.v)),
+        _muladd(mode, a.v, b.h, _muladd(mode, b.v, a.h, symouter(mode, a.g, b.g))),
+    )
+end
+
+# Dedicated division rule, mirroring _div_hyperdual:
+# f = x/y, fₓ = 1/y, fᵧ = -f/y, fₓₓ = 0, fₓᵧ = -1/y², fᵧᵧ = 2f/y²
+@inline function _div_jet(mode::ArithmeticMode, a::Jet{N, M, T}, b::Jet{N, M, T}) where {N, M, T}
+    x, y = a.v, b.v
+    invy = _inv(mode, y)
+    f = _mul(mode, x, invy)
+    fᵧ = _neg(mode, _mul(mode, f, invy))
+    fₓᵧ = _mul(mode, _neg(mode, invy), invy)
+    fᵧᵧ = _mul(mode, _mul(mode, _neg(mode, 2), fᵧ), invy)
+    return chain_rule_jet(mode, a, b, f, invy, fᵧ, zero(invy), fₓᵧ, fᵧᵧ)
+end
+
+# f(y) = r/y: f′ = -f/y, f′′ = 2f/y²
+@inline function _rdiv_jet(mode::ArithmeticMode, r::Real, j::Jet{N, M}) where {N, M}
+    r, y = promote(r, j.v)
+    invy = _inv(mode, y)
+    f = _mul(mode, r, invy)
+    f′ = _neg(mode, _mul(mode, f, invy))
+    f′′ = _mul(mode, _mul(mode, _neg(mode, 2), f′), invy)
+    return chain_rule_jet(mode, j, f, f′, f′′)
+end
+
+@inline Base.:+(j::Jet) = j
+@inline Base.:-(j::Jet) = _neg_jet(_ieee_mode(j), j)
+
+@inline Base.:+(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _add_jet(IEEEArithmetic{S}(), a, b)
+@inline Base.:+(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = +(promote(a, b)...)
+@inline Base.:+(j::Jet{N, M, T, S}, r::Real) where {N, M, T, S} =
+    jet(Val(S), j.v + r, j.g, j.h)
+@inline Base.:+(r::Real, j::Jet{N, M, T, S}) where {N, M, T, S} =
+    jet(Val(S), r + j.v, j.g, j.h)
+
+@inline Base.:-(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _sub_jet(IEEEArithmetic{S}(), a, b)
+@inline Base.:-(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = -(promote(a, b)...)
+@inline Base.:-(j::Jet{N, M, T, S}, r::Real) where {N, M, T, S} =
+    jet(Val(S), j.v - r, j.g, j.h)
+@inline function Base.:-(r::Real, j::Jet{N, M}) where {N, M}
+    mode = _ieee_mode(j)
+    return jet(mode, r - j.v, _neg(mode, j.g), _neg(mode, j.h))
+end
+
+@inline Base.:*(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _mul_jet(IEEEArithmetic{S}(), a, b)
+@inline Base.:*(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = *(promote(a, b)...)
+@inline function Base.:*(j::Jet{N, M}, r::Real) where {N, M}
+    mode = _ieee_mode(j)
+    return jet(mode, j.v * r, _mul(mode, j.g, r), _mul(mode, j.h, r))
+end
+@inline function Base.:*(r::Real, j::Jet{N, M}) where {N, M}
+    mode = _ieee_mode(j)
+    return jet(mode, r * j.v, _mul(mode, r, j.g), _mul(mode, r, j.h))
+end
+
+@inline Base.:/(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _div_jet(IEEEArithmetic{S}(), a, b)
+@inline Base.:/(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = /(promote(a, b)...)
+@inline function Base.:/(j::Jet{N, M}, r::Real) where {N, M}
+    mode = _ieee_mode(j)
+    return jet(mode, j.v / r, _div(mode, j.g, r), _div(mode, j.h, r))
+end
+@inline Base.:/(r::Real, j::Jet) = _rdiv_jet(_ieee_mode(j), r, j)
+
+# Integer powers, mirroring _pow_hyperdual: monomial derivatives directly
+# (NaN-free at x = 0, cheaper than repeated multiplication), and resolving the
+# ambiguity with Base.^(::Number, ::Integer).
+@inline function _pow_jet(mode::ArithmeticMode, j::Jet, n::Integer)
+    x = j.v
+    if n == 0
+        return one(j)
+    elseif n == 1
+        return j
+    elseif n == 2
+        return chain_rule_jet(mode, j, _mul(mode, x, x), _mul(mode, 2, x), _mul(mode, 2, one(x)))
+    elseif n == 3
+        x2 = _mul(mode, x, x)
+        return chain_rule_jet(mode, j, _mul(mode, x2, x), _mul(mode, 3, x2), _mul(mode, 6, x))
+    else
+        p = _pow(mode, x, n - 2)
+        xp = _mul(mode, x, p)
+        f = _mul(mode, x, xp)
+        f′ = _mul(mode, n, xp)
+        f′′ = _mul(mode, n * (n - 1), p)
+        return chain_rule_jet(mode, j, f, f′, f′′)
+    end
+end
+@inline Base.:(^)(j::Jet, n::Integer) = _pow_jet(_ieee_mode(j), j, n)
+@inline Base.:(^)(j::Jet, r::Rational) = j^float(r)
+@inline Base.literal_pow(::typeof(^), j::Jet, ::Val{0}) = one(typeof(j))
+@inline Base.literal_pow(::typeof(^), j::Jet, ::Val{1}) = j
+@inline Base.literal_pow(::typeof(^), j::Jet, ::Val{p}) where {p} = j^p
+
+@inline function Base.muladd(x::Jet{N, M, T, S}, y::Real, z::Jet{N, M, T, S}) where {N, M, T, S}
+    mode = IEEEArithmetic{S}()
+    return jet(
+        mode,
+        muladd(x.v, y, z.v),
+        _muladd(mode, y, x.g, z.g),
+        _muladd(mode, y, x.h, z.h),
+    )
+end
+@inline Base.muladd(x::Real, y::Jet{N, M, T, S}, z::Jet{N, M, T, S}) where {N, M, T, S} =
+    muladd(y, x, z)
+@inline function Base.muladd(x::Jet{N, M, T, S}, y::Real, z::Real) where {N, M, T, S}
+    mode = IEEEArithmetic{S}()
+    return jet(mode, muladd(x.v, y, z), _mul(mode, x.g, y), _mul(mode, x.h, y))
+end
+@inline Base.muladd(x::Real, y::Jet{N, M, T, S}, z::Real) where {N, M, T, S} = muladd(y, x, z)
+@inline Base.muladd(x::Real, y::Real, z::Jet{N, M, T, S}) where {N, M, T, S} =
+    jet(Val(S), muladd(x, y, z.v), z.g, z.h)
+# All-Jet multiplicands are ambiguous between the mixed methods above, so
+# resolve them explicitly via the general product-then-sum.
+@inline Base.muladd(x::Jet{N, M, T, S}, y::Jet{N, M, T, S}, z::Jet{N, M, T, S}) where {N, M, T, S} =
+    x * y + z
+@inline Base.muladd(x::Jet{N, M, T, S}, y::Jet{N, M, T, S}, z::Real) where {N, M, T, S} =
+    x * y + z
+# Same-shape jets with mismatched T or S in any combination of slots are
+# otherwise dispatch-ambiguous among the scalar-slot methods above (a Real
+# slot matches a jet of a different parameterization). Enumerate every
+# pattern explicitly and promote to a common type, mirroring HyperDual.
+@inline Base.muladd(x::Jet{N, M, T1, S1}, y::Jet{N, M, T2, S2}, z::Jet{N, M, T1, S1}) where {N, M, T1, T2, S1, S2} =
+    muladd(promote(x, y, z)...)
+@inline Base.muladd(x::Jet{N, M, T2, S2}, y::Jet{N, M, T1, S1}, z::Jet{N, M, T1, S1}) where {N, M, T1, T2, S1, S2} =
+    muladd(promote(x, y, z)...)
+@inline Base.muladd(x::Jet{N, M, T1, S1}, y::Jet{N, M, T1, S1}, z::Jet{N, M, T2, S2}) where {N, M, T1, T2, S1, S2} =
+    muladd(promote(x, y, z)...)
+@inline Base.muladd(x::Jet{N, M, T1, S1}, y::Jet{N, M, T2, S2}, z::Jet{N, M, T3, S3}) where {N, M, T1, T2, T3, S1, S2, S3} =
+    muladd(promote(x, y, z)...)
+@inline Base.muladd(x::Jet{N, M, T1, S1}, y::Jet{N, M, T2, S2}, z::Real) where {N, M, T1, T2, S1, S2} =
+    muladd(promote(x, y, z)...)
+@inline Base.muladd(x::Jet{N, M, T1, S1}, y::Real, z::Jet{N, M, T2, S2}) where {N, M, T1, T2, S1, S2} =
+    muladd(promote(x, y, z)...)
+@inline Base.muladd(x::Real, y::Jet{N, M, T1, S1}, z::Jet{N, M, T2, S2}) where {N, M, T1, T2, S1, S2} =
+    muladd(promote(x, y, z)...)
+
+# Comparisons and predicates act on the primal value (HyperDual semantics).
+@inline Base.isless(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = isless(a.v, b.v)
+@inline Base.isless(j::Jet, r::Real) = isless(j.v, r)
+@inline Base.isless(r::Real, j::Jet) = isless(r, j.v)
+@inline Base.isless(j::Jet, r::AbstractFloat) = isless(j.v, r)
+@inline Base.isless(r::AbstractFloat, j::Jet) = isless(r, j.v)
+@inline Base.:<(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = a.v < b.v
+@inline Base.:<(j::Jet, r::Real) = j.v < r
+@inline Base.:<(r::Real, j::Jet) = r < j.v
+@inline Base.:<=(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = a.v <= b.v
+@inline Base.:<=(j::Jet, r::Real) = j.v <= r
+@inline Base.:<=(r::Real, j::Jet) = r <= j.v
+@inline Base.:(==)(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = a.v == b.v
+@inline Base.:(==)(j::Jet, r::Real) = j.v == r
+@inline Base.:(==)(r::Real, j::Jet) = r == j.v
+@inline Base.:(==)(j::Jet, r::AbstractIrrational) = j.v == r
+@inline Base.:(==)(r::AbstractIrrational, j::Jet) = r == j.v
+Base.hash(j::Jet, u::UInt) = hash(j.v, u)
+
+for f in (:isnan, :isinf, :isfinite, :signbit, :isinteger, :iseven, :isodd)
+    @eval @inline Base.$f(j::Jet) = $f(j.v)
+end
+
+# Rounding: derivative is zero almost everywhere.
+for f in (:floor, :ceil, :trunc)
+    @eval @inline function Base.$f(j::Jet{N, M, T, S}) where {N, M, T, S}
+        fv = $f(j.v)
+        return Jet{N, M, typeof(fv), S}(fv)
+    end
+    @eval @inline Base.$f(::Type{I}, j::Jet) where {I <: Real} = $f(I, j.v)
+end
+@inline function Base.round(j::Jet{N, M, T, S}, r::RoundingMode = RoundNearest) where {N, M, T, S}
+    fv = round(j.v, r)
+    return Jet{N, M, typeof(fv), S}(fv)
+end
+@inline Base.round(::Type{I}, j::Jet) where {I <: Real} = round(I, j.v)
+
+# mod/rem: derivative w.r.t. x is 1 almost everywhere.
+@inline Base.mod(j::Jet{N, M, T, S}, r::Real) where {N, M, T, S} =
+    jet(Val(S), mod(j.v, r), j.g, j.h)
+@inline Base.rem(j::Jet{N, M, T, S}, r::Real) where {N, M, T, S} =
+    jet(Val(S), rem(j.v, r), j.g, j.h)
+@inline Base.mod(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = a - fld(a.v, b.v) * b
+@inline Base.rem(a::Jet{N, M}, b::Jet{N, M}) where {N, M} = a - div(a.v, b.v) * b
+@inline Base.mod2pi(j::Jet{N, M, T, S}) where {N, M, T, S} =
+    jet(Val(S), mod2pi(j.v), j.g, j.h)
+@inline Base.rem2pi(j::Jet{N, M, T, S}, r::RoundingMode) where {N, M, T, S} =
+    jet(Val(S), rem2pi(j.v, r), j.g, j.h)
+
+# `@fastmath` rewrites user arithmetic to these functions. As for HyperDual,
+# the methods below select fast arithmetic for the primal and all derivative
+# components; the fast variants of the derivative rules are generated in
+# rules.jl.
+@inline Base.FastMath.sub_fast(j::Jet) = _neg_jet(_fast_mode(j), j)
+
+@inline Base.FastMath.add_fast(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _add_jet(FastArithmetic{S}(), a, b)
+@inline Base.FastMath.add_fast(a::Jet{N, M}, b::Jet{N, M}) where {N, M} =
+    Base.FastMath.add_fast(promote(a, b)...)
+@inline Base.FastMath.add_fast(j::Jet{N, M, T, S}, r::Real) where {N, M, T, S} =
+    jet(Val(S), Base.FastMath.add_fast(j.v, r), j.g, j.h)
+@inline Base.FastMath.add_fast(r::Real, j::Jet{N, M, T, S}) where {N, M, T, S} =
+    jet(Val(S), Base.FastMath.add_fast(r, j.v), j.g, j.h)
+
+@inline Base.FastMath.sub_fast(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _sub_jet(FastArithmetic{S}(), a, b)
+@inline Base.FastMath.sub_fast(a::Jet{N, M}, b::Jet{N, M}) where {N, M} =
+    Base.FastMath.sub_fast(promote(a, b)...)
+@inline Base.FastMath.sub_fast(j::Jet{N, M, T, S}, r::Real) where {N, M, T, S} =
+    jet(Val(S), Base.FastMath.sub_fast(j.v, r), j.g, j.h)
+@inline function Base.FastMath.sub_fast(r::Real, j::Jet{N, M}) where {N, M}
+    mode = _fast_mode(j)
+    return jet(
+        mode,
+        Base.FastMath.sub_fast(r, j.v),
+        _neg(mode, j.g),
+        _neg(mode, j.h),
+    )
+end
+
+@inline Base.FastMath.mul_fast(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _mul_jet(FastArithmetic{S}(), a, b)
+@inline Base.FastMath.mul_fast(a::Jet{N, M}, b::Jet{N, M}) where {N, M} =
+    Base.FastMath.mul_fast(promote(a, b)...)
+@inline function Base.FastMath.mul_fast(j::Jet{N, M}, r::Real) where {N, M}
+    mode = _fast_mode(j)
+    return jet(
+        mode,
+        Base.FastMath.mul_fast(j.v, r),
+        _mul(mode, j.g, r),
+        _mul(mode, j.h, r),
+    )
+end
+@inline function Base.FastMath.mul_fast(r::Real, j::Jet{N, M}) where {N, M}
+    mode = _fast_mode(j)
+    return jet(
+        mode,
+        Base.FastMath.mul_fast(r, j.v),
+        _mul(mode, r, j.g),
+        _mul(mode, r, j.h),
+    )
+end
+
+@inline Base.FastMath.div_fast(a::Jet{N, M, T, S}, b::Jet{N, M, T, S}) where {N, M, T, S} =
+    _div_jet(FastArithmetic{S}(), a, b)
+@inline Base.FastMath.div_fast(a::Jet{N, M}, b::Jet{N, M}) where {N, M} =
+    Base.FastMath.div_fast(promote(a, b)...)
+@inline function Base.FastMath.div_fast(j::Jet{N, M}, r::Real) where {N, M}
+    mode = _fast_mode(j)
+    return jet(
+        mode,
+        Base.FastMath.div_fast(j.v, r),
+        _div(mode, j.g, r),
+        _div(mode, j.h, r),
+    )
+end
+@inline Base.FastMath.div_fast(r::Real, j::Jet) = _rdiv_jet(_fast_mode(j), r, j)
+
+@inline Base.FastMath.pow_fast(j::Jet, n::Integer) = _pow_jet(_fast_mode(j), j, n)
+@inline Base.FastMath.pow_fast(j::Jet, ::Val{p}) where {p} = _pow_jet(_fast_mode(j), j, p)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -307,6 +307,28 @@ end
     return hs, hc
 end
 
+@inline function Base.FastMath.sin_fast(j::Jet)
+    mode = _fast_mode(j)
+    s = Base.FastMath.sin_fast(j.v)
+    c = Base.FastMath.cos_fast(j.v)
+    return chain_rule_jet(mode, j, s, c, _neg(mode, s))
+end
+
+@inline function Base.FastMath.cos_fast(j::Jet)
+    mode = _fast_mode(j)
+    s = Base.FastMath.sin_fast(j.v)
+    c = Base.FastMath.cos_fast(j.v)
+    return chain_rule_jet(mode, j, c, _neg(mode, s), _neg(mode, c))
+end
+
+@inline function Base.FastMath.sincos_fast(j::Jet)
+    mode = _fast_mode(j)
+    s, c = Base.FastMath.sincos_fast(j.v)
+    js = chain_rule_jet(mode, j, s, c, _neg(mode, s))
+    jc = chain_rule_jet(mode, j, c, _neg(mode, s), _neg(mode, c))
+    return js, jc
+end
+
 @inline function Base.sinpi(h::HyperDual{N1, N2}) where {N1, N2}
     s, c = sincospi(h.v)
     return chain_rule_dual(h, s, π * c, -π^2 * s)
@@ -317,6 +339,26 @@ end
     return chain_rule_dual(h, c, -π * s, -π^2 * c)
 end
 
+@inline function Base.sin(j::Jet{N, M}) where {N, M}
+    s, c = sincos(j.v)
+    return chain_rule_jet(j, s, c, -s)
+end
+
+@inline function Base.cos(j::Jet{N, M}) where {N, M}
+    s, c = sincos(j.v)
+    return chain_rule_jet(j, c, -s, -c)
+end
+
+@inline function Base.sinpi(j::Jet{N, M}) where {N, M}
+    s, c = sincospi(j.v)
+    return chain_rule_jet(j, s, π * c, -π^2 * s)
+end
+
+@inline function Base.cospi(j::Jet{N, M}) where {N, M}
+    s, c = sincospi(j.v)
+    return chain_rule_jet(j, c, -π * s, -π^2 * c)
+end
+
 for (f, f′, f′′) in DIFF_RULES
     expr = rule_expr(f, f′, f′′)
     cse_expr = rule_cse(expr; warn = false)
@@ -324,6 +366,12 @@ for (f, f′, f′′) in DIFF_RULES
         x = h.v
         $cse_expr
         return chain_rule_dual(h, f, f′, f′′)
+    end
+
+    @eval @inline function Base.$f(j::Jet{N, M, T}) where {N, M, T}
+        x = j.v
+        $cse_expr
+        return chain_rule_jet(j, f, f′, f′′)
     end
 
     fast_sym = get(FAST_UNARY_OPS, f, nothing)
@@ -337,6 +385,15 @@ for (f, f′, f′′) in DIFF_RULES
         @fastmath begin
             $fast_cse_expr
             return chain_rule_dual(_fast_mode(h), h, f, f′, f′′)
+        end
+    end
+    @eval @inline function Base.FastMath.$fast_sym(
+            j::Jet{N, M, T}
+        ) where {N, M, T}
+        x = j.v
+        @fastmath begin
+            $fast_cse_expr
+            return chain_rule_jet(_fast_mode(j), j, f, f′, f′′)
         end
     end
 end
@@ -369,6 +426,30 @@ for (f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ) in BINARY_DIFF_RULES
         y = hy.v
         $cse_expr
         return chain_rule_dual(hy, f, fᵧ, fᵧᵧ)
+    end
+
+    @eval @inline function Base.$f(jx::Jet{N, M, T, S}, jy::Jet{N, M, T, S}) where {N, M, T, S}
+        x = jx.v
+        y = jy.v
+        $cse_expr
+        return chain_rule_jet(jx, jy, f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ)
+    end
+    @eval @inline function Base.$f(jx::Jet{N, M}, jy::Jet{N, M}) where {N, M}
+        return Base.$f(promote(jx, jy)...)
+    end
+    @eval @inline function Base.$f(jx::Jet{N, M, T}, y_raw::Real) where {N, M, T}
+        y_raw isa Jet{N, M} && return Base.$f(promote(jx, y_raw)...)
+        x = jx.v
+        y = y_raw
+        $cse_expr
+        return chain_rule_jet(jx, f, fₓ, fₓₓ)
+    end
+    @eval @inline function Base.$f(x_raw::Real, jy::Jet{N, M, T}) where {N, M, T}
+        x_raw isa Jet{N, M} && return Base.$f(promote(x_raw, jy)...)
+        x = x_raw
+        y = jy.v
+        $cse_expr
+        return chain_rule_jet(jy, f, fᵧ, fᵧᵧ)
     end
 
     fast_sym = FAST_BINARY_OPS[f]
@@ -411,6 +492,44 @@ for (f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ) in BINARY_DIFF_RULES
             return chain_rule_dual(_fast_mode(hy), hy, f, fᵧ, fᵧᵧ)
         end
     end
+
+    @eval @inline function Base.FastMath.$fast_sym(
+            jx::Jet{N, M, T, S}, jy::Jet{N, M, T, S}
+        ) where {N, M, T, S}
+        x = jx.v
+        y = jy.v
+        @fastmath begin
+            $fast_cse_expr
+            return chain_rule_jet(_fast_mode(jx), jx, jy, f, fₓ, fᵧ, fₓₓ, fₓᵧ, fᵧᵧ)
+        end
+    end
+    @eval @inline function Base.FastMath.$fast_sym(
+            jx::Jet{N, M}, jy::Jet{N, M}
+        ) where {N, M}
+        return Base.FastMath.$fast_sym(promote(jx, jy)...)
+    end
+    @eval @inline function Base.FastMath.$fast_sym(
+            jx::Jet{N, M, T}, y_raw::Real
+        ) where {N, M, T}
+        y_raw isa Jet{N, M} && return Base.FastMath.$fast_sym(promote(jx, y_raw)...)
+        x = jx.v
+        y = y_raw
+        @fastmath begin
+            $fast_cse_expr
+            return chain_rule_jet(_fast_mode(jx), jx, f, fₓ, fₓₓ)
+        end
+    end
+    @eval @inline function Base.FastMath.$fast_sym(
+            x_raw::Real, jy::Jet{N, M, T}
+        ) where {N, M, T}
+        x_raw isa Jet{N, M} && return Base.FastMath.$fast_sym(promote(x_raw, jy)...)
+        x = x_raw
+        y = jy.v
+        @fastmath begin
+            $fast_cse_expr
+            return chain_rule_jet(_fast_mode(jy), jy, f, fᵧ, fᵧᵧ)
+        end
+    end
 end
 # NOTE: `^(::HyperDual, ::Integer)` is defined in hyperdual.jl with dedicated
 # monomial derivatives (the generic rule divides by x and is NaN at x = 0);
@@ -420,6 +539,8 @@ end
 # Base.log(::Irrational{:ℯ}, ::Number).
 @inline Base.:(^)(::Irrational{:ℯ}, h::HyperDual) = exp(h)
 @inline Base.log(::Irrational{:ℯ}, h::HyperDual) = log(h)
+@inline Base.:(^)(::Irrational{:ℯ}, j::Jet) = exp(j)
+@inline Base.log(::Irrational{:ℯ}, j::Jet) = log(j)
 
 
 """

--- a/test/forwarddiff_tests.jl
+++ b/test/forwarddiff_tests.jl
@@ -2,18 +2,24 @@ module ForwardDiffTests
 
 using Test
 using HyperHessians
-using HyperHessians: HyperDual
+using HyperHessians: HyperDual, Jet
 using ForwardDiff
 
 @testset "extension loads" begin
     @test Base.get_extension(HyperHessians, :HyperHessiansForwardDiffExt) !== nothing
 end
 
-@testset "no HyperDual/Dual ambiguities" begin
+@testset "no HyperDual/Jet vs Dual ambiguities" begin
     ambs = Test.detect_ambiguities(Base, HyperHessians, ForwardDiff; recursive = false)
     bad = filter(ambs) do (m1, m2)
         s = string(m1.sig) * string(m2.sig)
-        occursin("HyperDual", s) && occursin(r"ForwardDiff\.Dual", s)
+        occursin(r"ForwardDiff\.Dual", s) || return false
+        # Pairs mixing Jet with HyperDual are only reachable through
+        # nonsensical three-way Jet/HyperDual/Dual calls and are deliberately
+        # left ambiguous (see hyperdual_interface_tests.jl); 1.10's
+        # detect_ambiguities reports them, 1.11+ does not.
+        occursin("HyperDual", s) && occursin("Jet", s) && return false
+        return occursin("HyperDual", s) || occursin("Jet", s)
     end
     isempty(bad) || foreach(p -> println(p[1].sig, "\n    <-> ", p[2].sig), bad)
     @test isempty(bad)
@@ -56,6 +62,41 @@ end
         vals = map(a -> a isa HyperDual ? a.v : a isa ForwardDiff.Dual ? ForwardDiff.value(a) : a, args)
         @test HyperHessians.value(ForwardDiff.value(r)) ≈ muladd(float.(vals)...) rtol = 1.0e-14
     end
+end
+
+@testset "mixed Jet/Dual arithmetic" begin
+    j = Jet(2.0, (1.0,), (1.0,))
+    d = ForwardDiff.Dual{Nothing}(3.0, 1.0)
+
+    primal(x) = x isa Jet ? x.v : ForwardDiff.value(x)
+    for op in (+, -, *, /, ^, atan, hypot, log, mod, rem)
+        for (a, b) in ((j, d), (d, j))
+            r = op(a, b)
+            @test r isa ForwardDiff.Dual{Nothing, <:Jet}
+            @test HyperHessians.value(ForwardDiff.value(r)) ≈ op(primal(a), primal(b)) rtol = 1.0e-14
+        end
+    end
+    @test ForwardDiff.NaNMath.pow(j, d) isa ForwardDiff.Dual{Nothing, <:Jet}
+    @test ForwardDiff.NaNMath.pow(d, j) isa ForwardDiff.Dual{Nothing, <:Jet}
+    @test j < d && isless(j, d) && !(j == d)
+    @test promote_type(typeof(j), typeof(d)) == ForwardDiff.Dual{Nothing, typeof(j), 1}
+
+    for args in (
+            (j, d, 1.0), (d, j, 1.0), (1.0, j, d), (j, 1.0, d), (j, d, j), (d, j, d),
+            (d, π, j), (j, 2, d), (j, d, 1 // 2), (2, d, j),
+        )
+        r = muladd(args...)
+        @test r isa ForwardDiff.Dual{Nothing, <:Jet}
+        vals = map(a -> a isa Jet ? a.v : a isa ForwardDiff.Dual ? ForwardDiff.value(a) : a, args)
+        @test HyperHessians.value(ForwardDiff.value(r)) ≈ muladd(float.(vals)...) rtol = 1.0e-14
+    end
+end
+
+@testset "ForwardDiff.derivative inside jet hessian" begin
+    f(x) = ForwardDiff.derivative(y -> y^2 * sqrt(sum(abs2, x)) + atan(y, x[1]) + hypot(x[2], y), 2.0)
+    x = [0.3, 0.4, 0.5]
+    cfg = HyperHessians.HessianConfig(x, Jet)
+    @test HyperHessians.hessian(f, x, cfg) ≈ ForwardDiff.hessian(f, x)
 end
 
 @testset "ForwardDiff.derivative inside hessian" begin

--- a/test/hyperdual_interface_tests.jl
+++ b/test/hyperdual_interface_tests.jl
@@ -138,12 +138,14 @@ end
     @test HyperDual{1, 1}(h) === h
 end
 
-# Guard against ambiguities with Base/Core methods only. Internal
-# HyperDual-vs-HyperDual pairs are only reachable with mismatched chunk sizes
-# (a nonsensical call). Clashes with other <:Real dual types (e.g.
-# ForwardDiff.Dual, if co-loaded) are mutually ambiguous but unresolvable
-# without depending on those packages, and mixing two AD systems in one op is
-# nonsensical anyway. Both are filtered out.
+# Guard against ambiguities with Base/Core methods only. Internal pairs —
+# HyperDual-vs-HyperDual with mismatched shapes, and Jet-vs-HyperDual
+# crossings — are only reachable by mixing representations that never meet
+# through the config API, so they are deliberately left ambiguous. Clashes
+# with other <:Real dual types (e.g. ForwardDiff.Dual, if co-loaded) are
+# mutually ambiguous but unresolvable without depending on those packages,
+# and mixing two AD systems in one op is nonsensical anyway. Both are
+# filtered out.
 @testset "no ambiguities against Base methods" begin
     ambs = Test.detect_ambiguities(HyperHessians; recursive = true)
     isbasecore(m) = (r = Base.moduleroot(m.module); r === Base || r === Core)

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -1,0 +1,274 @@
+module JetTests
+
+# The symmetric Jet number computes the whole Hessian in a single evaluation,
+# storing the gradient once and only the upper triangle. It is an explicit
+# opt-in: `HessianConfig(x, Jet[; simd])`. These tests pin that dispatch and
+# check the Jet path against the HyperDual path and ForwardDiff.
+
+using Test
+using HyperHessians: HyperHessians, hessian, hessian!, hessian_gradient_value,
+    hessian_gradient_value!, HessianConfig, Chunk, Jet
+using DiffTests
+using ForwardDiff
+using NaNMath
+using SpecialFunctions
+using LogExpFunctions
+
+@testset "config dispatch" begin
+    # jets are never the default
+    for n in (1, 2, 3, 4, 20)
+        @test eltype(HessianConfig(rand(n)).duals) <: HyperHessians.HyperDual
+    end
+    for n in (1, 3, 8), simd in (false, true)
+        cfg = HessianConfig(rand(n), Jet; simd)
+        @test eltype(cfg.duals) === Jet{n, HyperHessians.nupper(n), Float64, simd}
+        @test HyperHessians.chunksize(cfg) == n
+    end
+    @test_throws ArgumentError HessianConfig(zeros(0), Jet)
+    # malformed triangle length fails at construction, not deep in a rule
+    @test_throws ArgumentError Jet(1.0, (1.0, 2.0), (1.0,))
+end
+
+issymmetric(H) = H == H'
+
+@testset "jet vs hyperdual vs ForwardDiff: $(f)" for f in (
+        DiffTests.ackley,
+        DiffTests.rosenbrock_1,
+        DiffTests.self_weighted_logit,
+        x -> sum(abs2, x),
+    )
+    for n in (1, 2, 3, 5, 8), simd in (false, true)
+        x = rand(n) .+ 0.1
+        H_jet = hessian(f, x, HessianConfig(x, Jet; simd))
+        H_hd = hessian(f, x, HessianConfig(x, Chunk{n}()))
+        H_fd = ForwardDiff.hessian(f, x)
+        @test H_jet ≈ H_hd rtol = 1.0e-12
+        @test H_jet ≈ H_fd rtol = 1.0e-8
+        @test issymmetric(H_jet)
+    end
+end
+
+@testset "binary and special rules through jets (simd = $simd)" for simd in (false, true)
+    fns = (
+        v -> v[1]^v[2] + atan(v[1], v[2]) + hypot(v[1], v[2]),
+        v -> log(v[2], v[1] + 1) + v[1]^3 + v[2]^-2 + sinpi(v[1] / 4),
+        v -> abs(v[1]) * exp(-v[2]) + (v[1] < v[2] ? v[1] * v[2] : v[2]),
+        v -> muladd(v[1], 2.0, v[2]) + muladd(v[1], v[2], v[1]) + mod(v[1], 10) + floor(v[2]) * v[1],
+    )
+    for f in fns
+        x = rand(2) .+ 0.5
+        H_jet = hessian(f, x, HessianConfig(x, Jet; simd))
+        H_fd = ForwardDiff.hessian(f, x)
+        @test H_jet ≈ H_fd rtol = 1.0e-8
+    end
+end
+
+@testset "hessian_gradient_value through jets" begin
+    f = DiffTests.ackley
+    x = rand(3)
+    cfg = HessianConfig(x, Jet)
+    res = hessian_gradient_value(f, x, cfg)
+    @test res.value ≈ f(x)
+    @test res.gradient ≈ ForwardDiff.gradient(f, x)
+    @test res.hessian ≈ ForwardDiff.hessian(f, x)
+
+    H = zeros(3, 3)
+    G = zeros(3)
+    v = hessian_gradient_value!(H, G, f, x, cfg)
+    @test v ≈ f(x)
+    @test G ≈ res.gradient
+    @test H ≈ res.hessian
+end
+
+@testset "Float32 jets (simd = $simd)" for simd in (false, true)
+    f = x -> sum(abs2, x) + sin(x[1])
+    x = rand(Float32, 3)
+    cfg = HessianConfig(x, Jet; simd)
+    @test eltype(cfg.duals) == Jet{3, 6, Float32, simd}
+    H = hessian(f, x, cfg)
+    @test eltype(H) == Float32
+    @test H ≈ ForwardDiff.hessian(f, x) rtol = 1.0e-4
+end
+
+@testset "mixed-precision scalars through jets" begin
+    x = Float32[1, 2]
+    cfg = HessianConfig(x, Jet)
+    cfg_hd = HessianConfig(x, Chunk{2}())
+    fns = (
+        v -> v[1] + 2.1,
+        v -> v[1] - 2.1,
+        v -> 2.1 - v[1] * v[2],
+        v -> @fastmath(v[1] + 2.1 * v[2] - 1.5),
+        v -> mod(v[1], 10.0) * v[2],
+    )
+    for f in fns
+        @test hessian(f, x, cfg) ≈ hessian(f, x, cfg_hd)
+    end
+
+    # muladd promotes like its scalar counterpart instead of narrowing to the
+    # input type
+    for f in (
+            v -> muladd(v[1], 2.1, v[2]),
+            v -> muladd(2.1, v[1], v[2]),
+            v -> muladd(v[1], v[2], 2.1),
+            v -> muladd(v[1], 2.1, 0.5),
+            v -> muladd(2.1, 0.5, v[1]),
+        )
+        res = hessian_gradient_value(f, x, cfg)
+        @test res.value isa Float64
+        @test res.value ≈ f(x)
+        @test res.value == hessian_gradient_value(f, x, cfg_hd).value
+    end
+end
+
+@testset "simd jets behave like tuple jets" begin
+    # scalar mixing keeps the backend
+    j = Jet(1.5, (1.0, 0.0), (0.0, 0.0, 0.0))
+    js = convert(Jet{2, 3, Float64, true}, j)
+    for op in (x -> x + 1, x -> 2 * x, x -> x / 2, x -> x^3, x -> muladd(x, 2.0, x), one, x -> mod(x, 2.0), exp, -)
+        @test typeof(op(js)) === typeof(js)
+        rt = op(j)
+        rs = op(js)
+        @test rs.v == rt.v && rs.g == rt.g && rs.h == rt.h
+    end
+    # mixed backends promote toward tuple
+    @test typeof(js + j) === typeof(j)
+    # Int scalars fall back to the generic tuple ops but still work
+    @test (js * 2).v == 3.0
+
+    # mixed backends in binary rules promote, independent of argument order
+    for op in (atan, hypot, ^, log, muladd)
+        rt = op === muladd ? muladd(j, j, j) : op(j, j)
+        for mixed in (
+                op === muladd ? (muladd(js, j, js), muladd(j, js, j), muladd(js, js, j)) :
+                    (op(js, j), op(j, js))
+            )
+            @test typeof(mixed) === typeof(j)
+            @test mixed.v == rt.v && mixed.g == rt.g && mixed.h == rt.h
+        end
+    end
+    # same-shape jets in scalar slots must not nest into Jet-of-Jet
+    @test muladd(js, j, 1.0) isa Jet{2, 3, Float64, false}
+    @test muladd(js, j, 1.0).v == muladd(j, j, 1.0).v
+
+    # NaNMath scalar slots promote instead of narrowing to the component type
+    j32 = Jet(1.2f0, (1.0f0,), (1.0f0,))
+    @test NaNMath.pow(j32, 2.5).v === NaNMath.pow(1.2f0, 2.5)
+    @test NaNMath.pow(2.5, j32).v === NaNMath.pow(2.5, 1.2f0)
+end
+
+# Minimal non-one-based vector/matrix for testing extraction.
+struct OffsetVec{T} <: AbstractVector{T}
+    data::Vector{T}
+    off::Int
+end
+Base.size(v::OffsetVec) = size(v.data)
+Base.axes(v::OffsetVec) = (Base.IdentityUnitRange((1 + v.off):(length(v.data) + v.off)),)
+Base.getindex(v::OffsetVec, i::Int) = v.data[i - v.off]
+Base.setindex!(v::OffsetVec, x, i::Int) = (v.data[i - v.off] = x; v)
+
+struct OffsetMat{T} <: AbstractMatrix{T}
+    data::Matrix{T}
+    off::Int
+end
+Base.size(m::OffsetMat) = size(m.data)
+Base.axes(m::OffsetMat) =
+    map(n -> Base.IdentityUnitRange((1 + m.off):(n + m.off)), size(m.data))
+Base.getindex(m::OffsetMat, i::Int, j::Int) = m.data[i - m.off, j - m.off]
+Base.setindex!(m::OffsetMat, x, i::Int, j::Int) = (m.data[i - m.off, j - m.off] = x; m)
+
+@testset "jet extraction into non-one-based outputs" begin
+    f = DiffTests.ackley
+    x = rand(3)
+    cfg = HessianConfig(x, Jet)
+    H = OffsetMat(zeros(3, 3), 7)
+    G = OffsetVec(zeros(3), 5)
+    v = hessian_gradient_value!(H, G, f, x, cfg)
+    @test v ≈ f(x)
+    @test G.data ≈ ForwardDiff.gradient(f, x)
+    @test H.data ≈ ForwardDiff.hessian(f, x)
+end
+
+@testset "no allocations, no spurious promotions" begin
+    f = DiffTests.ackley
+    x = rand(3)
+    H = zeros(3, 3)
+    for simd in (false, true)
+        cfg = HessianConfig(x, Jet; simd)
+        hessian!(H, f, x, cfg) # warm up
+        @test @allocated(hessian!(H, f, x, cfg)) == 0
+    end
+    # Float32 jets stay Float32 through the rules, for both backends
+    for S in (false, true)
+        j = convert(Jet{2, 3, Float32, S}, Jet(1.2f0, (1.0f0, 0.0f0), (0.0f0, 0.0f0, 0.0f0)))
+        for op in (exp, sin, sqrt, log, abs2, x -> x^2, x -> x * 2.0f0, x -> x + 1, inv)
+            @test op(j) isa Jet{2, 3, Float32, S}
+        end
+    end
+end
+
+@testset "extension rules through jets: $(name)" for (name, f) in (
+        (
+            "NaNMath", v -> NaNMath.sqrt(v[1]) + NaNMath.log(v[2]) + NaNMath.pow(v[1], v[2]) +
+                NaNMath.pow(v[2], 2.5) + NaNMath.pow(v[1], 3) + NaNMath.sin(v[1]) +
+                NaNMath.lgamma(v[2] + 2),
+        ),
+        ("SpecialFunctions", v -> gamma(v[1]) + erf(v[2]) + digamma(v[1] + 2) + besselj0(v[2])),
+        ("LogExpFunctions", v -> logistic(v[1]) + xlogx(v[2]) + log1pexp(v[1]) + logit(v[2] / 2)),
+    )
+    for n in (2, 3), simd in (false, true)
+        x = rand(n) .+ 0.2
+        H_jet = hessian(f, x, HessianConfig(x, Jet; simd))
+        H_hd = hessian(f, x, HessianConfig(x, Chunk{n}()))
+        @test H_jet ≈ H_hd rtol = 1.0e-10
+    end
+end
+
+@testset "fastmath through jets (simd = $simd)" for simd in (false, true)
+    f = x -> @fastmath sin(x[1]) + x[1] * x[2] + x[2]^4 + exp(x[1]) / x[2] +
+        sqrt(x[2] + 2) - 3.0 * x[1] + x[1]^x[2] + cos(x[2])
+    x = rand(3) .+ 0.5
+    H_jet = hessian(f, x, HessianConfig(x, Jet; simd))
+    H_hd = hessian(f, x, HessianConfig(x, Chunk{3}()))
+    @test H_jet ≈ H_hd rtol = 1.0e-8
+end
+
+@testset "fastmath methods exist for jets" begin
+    # the fast-path methods must actually exist (not fall back to the slow ops)
+    for S in (false, true)
+        JT = Jet{2, 3, Float64, S}
+        for (fn, sig) in (
+                (Base.FastMath.mul_fast, Tuple{JT, JT}),
+                (Base.FastMath.add_fast, Tuple{JT, JT}),
+                (Base.FastMath.div_fast, Tuple{JT, JT}),
+                (Base.FastMath.sin_fast, Tuple{JT}),
+                (Base.FastMath.exp_fast, Tuple{JT}),
+                (Base.FastMath.sqrt_fast, Tuple{JT}),
+                (Base.FastMath.pow_fast, Tuple{JT, JT}),
+                (Base.FastMath.pow_fast, Tuple{JT, Int}),
+            )
+            @test which(fn, sig).module === HyperHessians
+        end
+    end
+end
+
+@testset "jet config at any size" begin
+    f = DiffTests.ackley
+    for n in (2, 10, 16), simd in (false, true)
+        x = rand(n)
+        cfg = HessianConfig(x, Jet; simd)
+        H_jet = hessian(f, x, cfg)
+        H_hd = hessian(f, x, HessianConfig(x, Chunk(x)))
+        @test H_jet ≈ H_hd rtol = 1.0e-10
+    end
+end
+
+@testset "jet config errors" begin
+    x = rand(3)
+    cfg = HessianConfig(x, Jet)
+    @test_throws DimensionMismatch hessian!(zeros(2, 2), DiffTests.ackley, x, cfg)
+    @test_throws DimensionMismatch hessian!(zeros(3, 3), DiffTests.ackley, rand(4), cfg)
+    @test_throws ErrorException hessian!(zeros(3, 3), x -> x, x, cfg)
+end
+
+end # module

--- a/test/rules_tests.jl
+++ b/test/rules_tests.jl
@@ -248,6 +248,13 @@ end
             check_binary_all_orders(f, x, y, T)
         end
     end
+    # Integer exponents forward to ^ (previously dispatch-ambiguous with
+    # NaNMath.pow(::Real, ::Integer))
+    check_against_ForwardDiff(x -> NaNMath.pow(x, 3), 1.2)
+    # scalar slots promote instead of narrowing to the dual's component type
+    h32 = HyperDual(1.2f0, (1.0f0,), (1.0f0,))
+    @test NaNMath.pow(h32, 2.5).v === NaNMath.pow(1.2f0, 2.5)
+    @test NaNMath.pow(2.5, h32).v === NaNMath.pow(2.5, 1.2f0)
 end
 
 @testset "SpecialFunctions boundary rules" begin


### PR DESCRIPTION
## What

A `Jet{N, M, T, S}` is `HyperDual{N, N}` specialized to the case where both derivative directions carry the same seeds — which is exactly what happens when the whole Hessian is computed in a single evaluation. In that case `ϵ₁ == ϵ₂` holds at every intermediate value and the cross block is symmetric, so the HyperDual stores (and computes) the gradient twice and both triangles of the block. A Jet stores each once:

- fields: `v`, `g::NTuple{N}`, `h::NTuple{M}` (upper triangle, `M = N(N+1)/2`) — 1+N+N(N+1)/2 floats instead of 1+2N+N²
- fully unrolled `@generated` triangle helpers, `muladd`-fused chain rules
- arithmetic parameterized over `ArithmeticMode` and the `S` backend flag like HyperDual: `@fastmath` in the differentiated function propagates through the derivative components, and `simd = true` forces SIMD.Vec arithmetic on the gradient and triangle tuples via the shared backend ops
- unary and binary derivative rules generated from the same `DIFF_RULES`/`BINARY_DIFF_RULES` tables as HyperDual, with the same S-parameterized signatures, promote fallbacks and `isa` guards
- all rule extensions emit Jet methods too (NaNMath incl. `pow`/`lgamma`, SpecialFunctions, LogExpFunctions), and the ForwardDiff ambiguity extension covers Jet/Dual mixing; DiffResults needed no changes

## Dispatch: explicit opt-in, never a default

`HessianConfig(x)` always uses HyperDuals; jets are selected only explicitly:

```julia
cfg = HessianConfig(x, Jet)              # jet representation
cfg = HessianConfig(x, Jet; simd = true) # with SIMD.Vec arithmetic
```

Jets tend to win for small inputs where register pressure dominates, while chunked HyperDuals vectorize better as the input grows. The crossover is function- and CPU-dependent (earlier measurements: clear jet win at n ≤ 3–4 on AVX2, up to n = 8 competitive on AVX-512/NEON for some functions), so instead of hardcoding a threshold, ChunkPicker.jl now benchmarks (chunks + Jet) × simd and recommends the winner. Jets are only sensible for small inputs: the unrolled triangle makes compile time grow steeply with `length(x)`, and with `simd = true` the triangle becomes one `N(N+1)/2`-lane `Vec`, which degrades sharply once that exceeds a few machine vector widths.

## Also fixed (surfaced by review, pre-existing on the HyperDual side too)

- `NaNMath.pow(dual, ::Integer)` was dispatch-ambiguous with `NaNMath.pow(::Real, ::Integer)`; both types now forward to `^`
- the NaNMath scalar-slot rules narrowed mixed-precision scalars to the dual's component type instead of promoting
- `symmetrize!` (and the new jet mirror) indexed non-1-based axes with 1-based positions

## Tests

New `test/jet_tests.jl`: config dispatch (never default, simd flavors, inference), jet vs HyperDual vs ForwardDiff across functions/sizes/backends, binary/special rules, `hessian_gradient_value`, Float32 and mixed precision, simd-vs-tuple backend equivalence and promotion, non-1-based outputs, allocation-freeness, `@fastmath` (including that the fast-path methods actually resolve to HyperHessians), all three rule extensions, ForwardDiff mixing, and error paths. Full existing test battery passes.
