### PR TITLE
Add ForwardDiff extension resolving HyperDual/Dual ambiguities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HyperHessians"
 uuid = "06b494a0-c8e0-40cc-ad32-d99506a00a6c"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["KristofferC <kcarlsson89@gmail.com>"]
 
 [deps]
@@ -8,6 +8,7 @@ CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"
 
 [weakdeps]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -15,6 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 HyperHessiansDiffResultsExt = "DiffResults"
+HyperHessiansForwardDiffExt = "ForwardDiff"
 HyperHessiansLogExpFunctionsExt = "LogExpFunctions"
 HyperHessiansNaNMathExt = "NaNMath"
 HyperHessiansNaNMathSpecialFunctionsExt = ["NaNMath", "SpecialFunctions"]

--- a/ext/HyperHessiansForwardDiffExt.jl
+++ b/ext/HyperHessiansForwardDiffExt.jl
@@ -1,0 +1,42 @@
+module HyperHessiansForwardDiffExt
+
+# Mixing HyperDual (e.g. from hessian seeding) with ForwardDiff.Dual (e.g.
+# from a derivative computed inside the function being differentiated) is
+# ambiguous out of the box, since both packages define methods against
+# ::Real. Resolve the ambiguities by letting the Dual wrap the HyperDual,
+# just like ForwardDiff wraps any other Real: forward to the ForwardDiff
+# method with the HyperDual passed as a generic Real scalar.
+
+using HyperHessians: HyperDual
+using ForwardDiff: ForwardDiff, Dual
+
+for f in (:+, :-, :*, :/, :^, :atan, :hypot, :log, :<, :<=, :(==), :isless)
+    @eval begin
+        @inline Base.$f(h::HyperDual, d::Dual) = invoke(Base.$f, Tuple{Real, typeof(d)}, h, d)
+        @inline Base.$f(d::Dual, h::HyperDual) = invoke(Base.$f, Tuple{typeof(d), Real}, d, h)
+    end
+end
+@inline Base.mod(h::HyperDual, d::Dual) = invoke(Base.mod, Tuple{Real, typeof(d)}, h, d)
+@inline Base.rem(h::HyperDual, d::Dual) = invoke(Base.rem, Tuple{Real, typeof(d)}, h, d)
+@inline ForwardDiff.NaNMath.pow(h::HyperDual, d::Dual) = invoke(ForwardDiff.NaNMath.pow, Tuple{Real, typeof(d)}, h, d)
+@inline ForwardDiff.NaNMath.pow(d::Dual, h::HyperDual) = invoke(ForwardDiff.NaNMath.pow, Tuple{typeof(d), Real}, d, h)
+
+Base.promote_rule(::Type{HyperDual{N1, N2, T}}, ::Type{Dual{Ty, V, N}}) where {N1, N2, T, Ty, V, N} =
+    Dual{Ty, promote_type(HyperDual{N1, N2, T}, V), N}
+
+# muladd: all mixed HyperDual/Dual argument combinations. ForwardDiff defines
+# its ternary ops against every type in AMBIGUOUS_TYPES (not just Real), so
+# the remaining non-HyperDual/non-Dual slot must be split over the same set
+# for the mixed methods to be strictly more specific than all of them.
+const _OTHERS = Tuple(T for T in ForwardDiff.AMBIGUOUS_TYPES if T <: Real)
+for pat in Iterators.product((:H, :D, :O), (:H, :D, :O), (:H, :D, :O))
+    (:H in pat && :D in pat) || continue
+    names = (:x, :y, :z)
+    ivk = [pat[i] === :H ? Real : :(typeof($(names[i]))) for i in 1:3]
+    for Q in (:O in pat ? _OTHERS : (nothing,))
+        sig = [:($(names[i])::$(pat[i] === :H ? HyperDual : pat[i] === :D ? Dual : Q)) for i in 1:3]
+        @eval @inline Base.muladd($(sig...)) = invoke(Base.muladd, Tuple{$(ivk...)}, x, y, z)
+    end
+end
+
+end # module

--- a/test/forwarddiff_tests.jl
+++ b/test/forwarddiff_tests.jl
@@ -1,0 +1,77 @@
+module ForwardDiffTests
+
+using Test
+using HyperHessians
+using HyperHessians: HyperDual
+using ForwardDiff
+
+@testset "extension loads" begin
+    @test Base.get_extension(HyperHessians, :HyperHessiansForwardDiffExt) !== nothing
+end
+
+@testset "no HyperDual/Dual ambiguities" begin
+    ambs = Test.detect_ambiguities(Base, HyperHessians, ForwardDiff; recursive = false)
+    bad = filter(ambs) do (m1, m2)
+        s = string(m1.sig) * string(m2.sig)
+        occursin("HyperDual", s) && occursin(r"ForwardDiff\.Dual", s)
+    end
+    isempty(bad) || foreach(p -> println(p[1].sig, "\n    <-> ", p[2].sig), bad)
+    @test isempty(bad)
+end
+
+@testset "mixed HyperDual/Dual arithmetic" begin
+    h = HyperDual(2.0, (1.0,), (1.0,))
+    d = ForwardDiff.Dual{Nothing}(3.0, 1.0)
+
+    # Dual wraps the HyperDual; the primal parts must match plain arithmetic
+    primal(x) = x isa HyperDual ? x.v : ForwardDiff.value(x)
+    for op in (+, -, *, /, ^, atan, hypot, log, mod, rem)
+        for (a, b) in ((h, d), (d, h))
+            r = op(a, b)
+            @test r isa ForwardDiff.Dual{Nothing, <:HyperDual}
+            @test HyperHessians.value(ForwardDiff.value(r)) ≈ op(primal(a), primal(b)) rtol = 1e-14
+        end
+    end
+    @test ForwardDiff.NaNMath.pow(h, d) isa ForwardDiff.Dual{Nothing, <:HyperDual}
+    @test ForwardDiff.NaNMath.pow(d, h) isa ForwardDiff.Dual{Nothing, <:HyperDual}
+
+    # comparisons act on primal values
+    @test h < d
+    @test d > h
+    @test h <= d
+    @test d >= h
+    @test isless(h, d)
+    @test !isless(d, h)
+    @test !(h == d)
+    @test promote_type(typeof(h), typeof(d)) == ForwardDiff.Dual{Nothing, typeof(h), 1}
+
+    # muladd mixes, including Integer/Irrational/Rational crossings
+    for args in (
+            (h, d, 1.0), (d, h, 1.0), (1.0, h, d), (1.0, d, h), (h, 1.0, d), (d, 1.0, h),
+            (h, d, h), (d, h, h), (h, h, d), (d, d, h), (h, d, d), (d, h, d),
+            (d, π, h), (h, 2, d), (h, d, 1 // 2), (2, d, h),
+        )
+        r = muladd(args...)
+        @test r isa ForwardDiff.Dual{Nothing, <:HyperDual}
+        vals = map(a -> a isa HyperDual ? a.v : a isa ForwardDiff.Dual ? ForwardDiff.value(a) : a, args)
+        @test HyperHessians.value(ForwardDiff.value(r)) ≈ muladd(float.(vals)...) rtol = 1e-14
+    end
+end
+
+@testset "ForwardDiff.derivative inside hessian" begin
+    # g(x) = d/dy sin(x*y) at y = 1.3  =>  g(x) = x*cos(1.3x)
+    g(x) = ForwardDiff.derivative(y -> sin(x * y), 1.3)
+    g′′(x) = -2.6 * sin(1.3 * x) - 1.69 * x * cos(1.3 * x)
+    res = HyperHessians.hessian_gradient_value(g, 0.7)
+    @test res.value ≈ g(0.7)
+    @test res.hessian ≈ g′′(0.7)
+
+    # vector input, mixed-op inner function
+    f(x) = ForwardDiff.derivative(y -> y^2 * sqrt(sum(abs2, x)) + atan(y, x[1]) + hypot(x[2], y), 2.0)
+    x = [0.3, 0.4, 0.5]
+    H = HyperHessians.hessian(f, x)
+    Href = ForwardDiff.hessian(f, x)
+    @test H ≈ Href
+end
+
+end # module

--- a/test/forwarddiff_tests.jl
+++ b/test/forwarddiff_tests.jl
@@ -29,7 +29,7 @@ end
         for (a, b) in ((h, d), (d, h))
             r = op(a, b)
             @test r isa ForwardDiff.Dual{Nothing, <:HyperDual}
-            @test HyperHessians.value(ForwardDiff.value(r)) ≈ op(primal(a), primal(b)) rtol = 1e-14
+            @test HyperHessians.value(ForwardDiff.value(r)) ≈ op(primal(a), primal(b)) rtol = 1.0e-14
         end
     end
     @test ForwardDiff.NaNMath.pow(h, d) isa ForwardDiff.Dual{Nothing, <:HyperDual}
@@ -54,7 +54,7 @@ end
         r = muladd(args...)
         @test r isa ForwardDiff.Dual{Nothing, <:HyperDual}
         vals = map(a -> a isa HyperDual ? a.v : a isa ForwardDiff.Dual ? ForwardDiff.value(a) : a, args)
-        @test HyperHessians.value(ForwardDiff.value(r)) ≈ muladd(float.(vals)...) rtol = 1e-14
+        @test HyperHessians.value(ForwardDiff.value(r)) ≈ muladd(float.(vals)...) rtol = 1.0e-14
     end
 end
 


### PR DESCRIPTION
Mixing `HyperDual` with `ForwardDiff.Dual` — e.g. a `ForwardDiff.derivative`/`gradient` call nested inside a function differentiated with `hessian` — currently throws method ambiguity errors, since both packages define arithmetic against `::Real`:

```julia
g(x) = ForwardDiff.derivative(y -> sin(x * y), 1.3)
HyperHessians.hessian(g, 0.7) # MethodError: *(::HyperDual{1,1,Float64}, ::Dual{...}) is ambiguous
```

This adds a `ForwardDiff` package extension that resolves the ambiguities by letting the `Dual` wrap the `HyperDual` (exactly like ForwardDiff wraps any other `Real`): each method forwards via `invoke` to the ForwardDiff method with the `HyperDual` passed as a generic `Real` scalar.

Covered: `+ - * /`, `^`, two-arg `atan`/`hypot`/`log`, `mod`/`rem`, comparisons (`< <= == isless`), `NaNMath.pow`, `promote_rule`, and all mixed `muladd` combinations. Since ForwardDiff defines its ternary ops against every entry of `ForwardDiff.AMBIGUOUS_TYPES`, the mixed `muladd` methods are generated over that same set (read from ForwardDiff at load time), keeping them strictly more specific across ForwardDiff versions.

Tests check that `detect_ambiguities` finds no remaining `HyperDual`/`Dual` pairs, primal-value correctness of all mixed ops, and end-to-end second derivatives of functions with nested ForwardDiff calls (validated against `ForwardDiff.hessian`).

Motivation: [Tensors.jl's experimental HyperDual-based `hessian`](https://github.com/Ferrite-FEM/Tensors.jl) needs this so functions that internally call `gradient` keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)