### PR TITLE
Measured function-agnostic default chunk rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,14 @@ The larger the chunk size the larger part of the Hessian is computed on every ca
 the input vector, the whole hessian is computed in one call to `f`).
 However, with a larger chunk size the special numbers HyperHessians uses become larger and if they become too large this can lead to inefficient execution.
 
-A choice of a chunk size is, therefore, a trade-off and the optimal one is likely to be dependent on the particular function getting differentiated.
-A decent overall choice seems to be a chunk size of 8.
-It is also in general a good idea to pick a chunk size as a multiple of 4 to use SIMD effectively.
+A choice of a chunk size is, therefore, a trade-off and the optimal one is likely to be dependent on the particular function getting differentiated:
+cheap functions favor small chunks (the dual size dominates), expensive ones favor SIMD-width multiples like 8, and
+[ChunkPicker.jl](https://github.com/KristofferC/ChunkPicker.jl) can benchmark the candidates for *your* function.
 
-The `chunk_size` argument can be left out and HyperHessians will try to determine a reasonable choice.
+The `chunk_size` argument can be left out, in which case HyperHessians uses a
+measured function-agnostic default: the whole Hessian in one evaluation for
+small inputs (`length(x) <= 10`, or 12 for `Float32`), then a small chunk
+(4, or 6 for large inputs and `Float32`).
 
 `HessianConfig` (and `ThreadedHessianConfig`) also accept a `simd` keyword:
 `simd = true` forces SIMD.Vec-based arithmetic for the derivative components

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -6,15 +6,19 @@ end
 
 Chunk(x::AbstractArray) = Chunk(length(x), eltype(x))
 
-# All 8 for now...
-maxchunksize(::Type{Float64}) = 8
-maxchunksize(::Type{Float32}) = 8
-maxchunksize(::Type{T}) where {T} = 8
-
+# Function-agnostic default measured over a benchmark grid (6 function
+# families x 20 input sizes x chunks, on AVX2, AVX-512 and NEON; see
+# ChunkPicker.jl's benchmark/RESULTS.md): full-vector single evaluation
+# while small, then a small chunk — large chunks only pay off for expensive
+# functions, which a default cannot know (benchmark with ChunkPicker.jl to
+# specialize). Float32 duals are half as wide, moving the thresholds up.
 function pickchunksize(input_length, ::Type{T}) where {T}
-    max_size = maxchunksize(T)
-    input_length <= max_size && return input_length
-    return max_size
+    input_length <= 10 && return Int(input_length)
+    return input_length <= 32 ? 4 : 6
+end
+function pickchunksize(input_length, ::Type{Float32})
+    input_length <= 12 && return Int(input_length)
+    return 6
 end
 
 chunksize(::Chunk{N}) where {N} = N::Int

--- a/test/chunk_tests.jl
+++ b/test/chunk_tests.jl
@@ -1,0 +1,27 @@
+module ChunkTests
+
+using Test
+using HyperHessians: Chunk, chunksize, pickchunksize
+
+@testset "pickchunksize" begin
+    for T in (Float64, Float32, BigFloat), n in 0:10
+        @test pickchunksize(n, T) == n
+    end
+    @test pickchunksize(11, Float64) == 4
+    @test pickchunksize(32, Float64) == 4
+    @test pickchunksize(33, Float64) == 6
+    @test pickchunksize(100, Float64) == 6
+    @test pickchunksize(64, BigFloat) == 6
+    # Float32 duals are half as wide; thresholds move up
+    @test pickchunksize(11, Float32) == 11
+    @test pickchunksize(12, Float32) == 12
+    @test pickchunksize(13, Float32) == 6
+    @test pickchunksize(100, Float32) == 6
+
+    @test chunksize(Chunk(rand(6))) == 6
+    @test chunksize(Chunk(rand(20))) == 4
+    @test chunksize(Chunk(rand(Float32, 20))) == 6
+    @test chunksize(Chunk(rand(64))) == 6
+end
+
+end # module


### PR DESCRIPTION
Replaces the `min(n, 8)` default in `pickchunksize` with thresholds derived from a 3-machine benchmark grid (AVX2 Arrow Lake, AVX-512 Zen 4, NEON M4 Pro; 6 function families × 20 input sizes × chunks, Float64 and Float32 — scripts, raw data and analysis live in ChunkPicker.jl, see KristofferC/ChunkPicker.jl#2):

- `n ≤ 10`: full vector (one evaluation) — extends the old ≤ 8; full-vector keeps winning through 10.
- `n ≤ 32`: chunk 4; above: chunk 6.
- Float32: full vector to 12, then 6 (half-width duals move the thresholds up).

Scored against the best fixed non-simd chunk per case (the default's action space):

| eltype | rule | geomean regret | p90 | max |
| --- | --- | --- | --- | --- |
| Float64 | `min(n, 8)` (old) | 1.44 | 3.10 | 5.72 |
| Float64 | new | 1.14 | 1.64 | 2.51 |
| Float32 | `min(n, 8)` (old) | 1.36 | 2.67 | 4.04 |
| Float32 | new | 1.23 | 1.79 | 2.32 |

The old default is worst around `n = 9..12` (geomean 2.3–2.9x there: chunk 8 on `n = 9` does three evaluations with 8-wide duals where full-vector does one). The remaining ~1.15x is function-dependent — cheap functions want tiny chunks, expensive ones want wide — which is what ChunkPicker.jl measures per function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)